### PR TITLE
Add DBML spec generation tooling

### DIFF
--- a/docs/model-spec.json
+++ b/docs/model-spec.json
@@ -1,0 +1,3355 @@
+{
+  "source": "DB.dbml",
+  "generatedAt": "2025-10-09T19:07:36.156Z",
+  "fixes": [],
+  "enums": {
+    "booking_status": {
+      "name": "booking_status",
+      "values": [
+        "pending_verification",
+        "verified",
+        "cancelled"
+      ]
+    },
+    "booking_verification_status": {
+      "name": "booking_verification_status",
+      "values": [
+        "pending",
+        "approved",
+        "rejected_mismatch",
+        "rejected_other"
+      ]
+    },
+    "confirmation_type": {
+      "name": "confirmation_type",
+      "values": [
+        "pickup",
+        "dropoff"
+      ]
+    },
+    "contract_status": {
+      "name": "contract_status",
+      "values": [
+        "issued",
+        "partially_signed",
+        "signed",
+        "voided",
+        "expired"
+      ]
+    },
+    "esign_provider": {
+      "name": "esign_provider",
+      "values": [
+        "native",
+        "docusign",
+        "adobesign",
+        "signnow",
+        "other"
+      ]
+    },
+    "fee_type": {
+      "name": "fee_type",
+      "values": [
+        "deposit",
+        "rental_charge",
+        "surcharge",
+        "damage",
+        "other"
+      ]
+    },
+    "inspection_type": {
+      "name": "inspection_type",
+      "values": [
+        "pre_rental",
+        "post_rental"
+      ]
+    },
+    "kyc_status": {
+      "name": "kyc_status",
+      "values": [
+        "submitted",
+        "approved",
+        "rejected",
+        "expired"
+      ]
+    },
+    "kyc_type": {
+      "name": "kyc_type",
+      "values": [
+        "national_id",
+        "driver_license",
+        "passport",
+        "other"
+      ]
+    },
+    "party_role": {
+      "name": "party_role",
+      "values": [
+        "renter",
+        "staff",
+        "other"
+      ]
+    },
+    "payment_method": {
+      "name": "payment_method",
+      "values": [
+        "unknown",
+        "cash",
+        "card",
+        "ewallet",
+        "bank_transfer"
+      ]
+    },
+    "payment_status": {
+      "name": "payment_status",
+      "values": [
+        "paid",
+        "refunded"
+      ]
+    },
+    "rental_status": {
+      "name": "rental_status",
+      "values": [
+        "reserved",
+        "in_progress",
+        "completed",
+        "late",
+        "cancelled"
+      ]
+    },
+    "signature_event_type": {
+      "name": "signature_event_type",
+      "values": [
+        "pickup",
+        "dropoff"
+      ]
+    },
+    "signature_type": {
+      "name": "signature_type",
+      "values": [
+        "drawn",
+        "typed",
+        "digital_cert"
+      ]
+    },
+    "transfer_status": {
+      "name": "transfer_status",
+      "values": [
+        "draft",
+        "approved",
+        "in_transit",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "user_role": {
+      "name": "user_role",
+      "values": [
+        "unknown",
+        "renter",
+        "staff",
+        "admin"
+      ]
+    },
+    "vehicle_at_stations_status_t": {
+      "name": "vehicle_at_stations_status_t",
+      "values": [
+        "maintain",
+        "available",
+        "booked"
+      ]
+    }
+  },
+  "collections": {
+    "admins": {
+      "tableName": "admins",
+      "collectionName": "admins",
+      "note": null,
+      "fields": [
+        {
+          "name": "user_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "title",
+          "dbmlType": "VARCHAR(100)",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "notes",
+          "dbmlType": "VARCHAR(500)",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "hire_date",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "users",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "vehicle_transfers",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "created_by_admin_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "vehicle_transfers",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "approved_by_admin_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "staff_transfers",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "created_by_admin_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "staff_transfers",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "approved_by_admin_id"
+          ],
+          "onDelete": null
+        }
+      ]
+    },
+    "bookings": {
+      "tableName": "bookings",
+      "collectionName": "bookings",
+      "note": null,
+      "fields": [
+        {
+          "name": "booking_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": true,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "renter_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "vehicle_at_station_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "booking_created_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "expected_return_datetime",
+          "dbmlType": "datetime",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "status",
+          "dbmlType": "booking_status",
+          "tsType": "enum:booking_status",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "pending_verification",
+          "note": null,
+          "enumName": "booking_status"
+        },
+        {
+          "name": "verification_status",
+          "dbmlType": "booking_verification_status",
+          "tsType": "enum:booking_verification_status",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "pending",
+          "note": null,
+          "enumName": "booking_verification_status"
+        },
+        {
+          "name": "verified_by_staff_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "verified_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "cancel_reason",
+          "dbmlType": "VARCHAR(1000)",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [
+        {
+          "name": "ix_bookings_renter",
+          "type": null,
+          "unique": false,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "renter_id"
+          ]
+        },
+        {
+          "name": "ix_bookings_vehicle_at_station",
+          "type": null,
+          "unique": false,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "vehicle_at_station_id"
+          ]
+        }
+      ],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "renters",
+          "sourceFields": [
+            "renter_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "belongsTo",
+          "targetCollection": "vehicle_at_stations",
+          "sourceFields": [
+            "vehicle_at_station_id"
+          ],
+          "targetFields": [
+            "vehicle_at_station_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "belongsTo",
+          "targetCollection": "staff",
+          "sourceFields": [
+            "verified_by_staff_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": "set null"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "fees",
+          "sourceFields": [
+            "booking_id"
+          ],
+          "targetFields": [
+            "booking_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "rentals",
+          "sourceFields": [
+            "booking_id"
+          ],
+          "targetFields": [
+            "booking_id"
+          ],
+          "onDelete": "cascade"
+        }
+      ]
+    },
+    "contracts": {
+      "tableName": "contracts",
+      "collectionName": "contracts",
+      "note": null,
+      "fields": [
+        {
+          "name": "contract_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": true,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "rental_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "version",
+          "dbmlType": "INT",
+          "tsType": "number",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": 1,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "status",
+          "dbmlType": "contract_status",
+          "tsType": "enum:contract_status",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "issued",
+          "note": null,
+          "enumName": "contract_status"
+        },
+        {
+          "name": "issued_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "completed_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "provider",
+          "dbmlType": "esign_provider",
+          "tsType": "enum:esign_provider",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "native",
+          "note": null,
+          "enumName": "esign_provider"
+        },
+        {
+          "name": "provider_envelope_id",
+          "dbmlType": "TEXT",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "document_url",
+          "dbmlType": "TEXT",
+          "tsType": "string",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "document_hash",
+          "dbmlType": "TEXT",
+          "tsType": "string",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "ltv_enabled",
+          "dbmlType": "BOOLEAN",
+          "tsType": "boolean",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": false,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "audit_trail_url",
+          "dbmlType": "TEXT",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "updated_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [],
+      "relations": [
+        {
+          "type": "hasOne",
+          "targetCollection": "rentals",
+          "sourceFields": [
+            "rental_id"
+          ],
+          "targetFields": [
+            "rental_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "signatures",
+          "sourceFields": [
+            "contract_id"
+          ],
+          "targetFields": [
+            "contract_id"
+          ],
+          "onDelete": "cascade"
+        }
+      ]
+    },
+    "fees": {
+      "tableName": "fees",
+      "collectionName": "fees",
+      "note": null,
+      "fields": [
+        {
+          "name": "fee_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": true,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "booking_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "type",
+          "dbmlType": "fee_type",
+          "tsType": "enum:fee_type",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "deposit",
+          "note": null,
+          "enumName": "fee_type"
+        },
+        {
+          "name": "description",
+          "dbmlType": "VARCHAR(200)",
+          "tsType": "string",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "amount",
+          "dbmlType": "NUMERIC(18,2)",
+          "tsType": "Decimal128",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "currency",
+          "dbmlType": "VARCHAR(10)",
+          "tsType": "string",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "USD",
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "created_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [
+        {
+          "name": "ux_fees_deposit_per_booking",
+          "type": null,
+          "unique": true,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "booking_id"
+          ]
+        }
+      ],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "bookings",
+          "sourceFields": [
+            "booking_id"
+          ],
+          "targetFields": [
+            "booking_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "payments",
+          "sourceFields": [
+            "fee_id"
+          ],
+          "targetFields": [
+            "payment_id"
+          ],
+          "onDelete": "cascade"
+        }
+      ]
+    },
+    "inspections": {
+      "tableName": "inspections",
+      "collectionName": "inspections",
+      "note": null,
+      "fields": [
+        {
+          "name": "inspection_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": true,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "rental_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "type",
+          "dbmlType": "inspection_type",
+          "tsType": "enum:inspection_type",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "pre_rental",
+          "note": null,
+          "enumName": "inspection_type"
+        },
+        {
+          "name": "inspected_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "inspector_staff_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "current_battery_capacity_kwh",
+          "dbmlType": "DOUBLEPRECISION",
+          "tsType": "number",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "current_mileage",
+          "dbmlType": "integer",
+          "tsType": "number",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [
+        {
+          "name": "ux_inspections_rental_type",
+          "type": null,
+          "unique": true,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "rental_id",
+            "type"
+          ]
+        }
+      ],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "rentals",
+          "sourceFields": [
+            "rental_id"
+          ],
+          "targetFields": [
+            "rental_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "belongsTo",
+          "targetCollection": "staff",
+          "sourceFields": [
+            "inspector_staff_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": "set null"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "reports",
+          "sourceFields": [
+            "inspection_id"
+          ],
+          "targetFields": [
+            "inspection_id"
+          ],
+          "onDelete": "cascade"
+        }
+      ]
+    },
+    "kycs": {
+      "tableName": "kycs",
+      "collectionName": "kycs",
+      "note": null,
+      "fields": [
+        {
+          "name": "kyc_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": true,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "renter_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "type",
+          "dbmlType": "kyc_type",
+          "tsType": "enum:kyc_type",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "driver_license",
+          "note": null,
+          "enumName": "kyc_type"
+        },
+        {
+          "name": "document_number",
+          "dbmlType": "VARCHAR(100)",
+          "tsType": "string",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "expiry_date",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "status",
+          "dbmlType": "kyc_status",
+          "tsType": "enum:kyc_status",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "submitted",
+          "note": null,
+          "enumName": "kyc_status"
+        },
+        {
+          "name": "submitted_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "verified_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [
+        {
+          "name": "ix_kycs_renter",
+          "type": null,
+          "unique": false,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "renter_id"
+          ]
+        }
+      ],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "renters",
+          "sourceFields": [
+            "renter_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": "cascade"
+        }
+      ]
+    },
+    "payments": {
+      "tableName": "payments",
+      "collectionName": "payments",
+      "note": null,
+      "fields": [
+        {
+          "name": "payment_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "method",
+          "dbmlType": "payment_method",
+          "tsType": "enum:payment_method",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "unknown",
+          "note": null,
+          "enumName": "payment_method"
+        },
+        {
+          "name": "status",
+          "dbmlType": "payment_status",
+          "tsType": "enum:payment_status",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "paid",
+          "note": null,
+          "enumName": "payment_status"
+        },
+        {
+          "name": "amount_paid",
+          "dbmlType": "NUMERIC(18,2)",
+          "tsType": "Decimal128",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "paid_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "provider_reference",
+          "dbmlType": "VARCHAR(200)",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "fees",
+          "sourceFields": [
+            "payment_id"
+          ],
+          "targetFields": [
+            "fee_id"
+          ],
+          "onDelete": "cascade"
+        }
+      ]
+    },
+    "pricings": {
+      "tableName": "pricings",
+      "collectionName": "pricings",
+      "note": null,
+      "fields": [
+        {
+          "name": "pricing_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": true,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "vehicle_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "price_per_hour",
+          "dbmlType": "NUMERIC(18,2)",
+          "tsType": "Decimal128",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "price_per_day",
+          "dbmlType": "NUMERIC(18,2)",
+          "tsType": "Decimal128",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "effective_from",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "effective_to",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "deposit_amount",
+          "dbmlType": "decimal(10,2)",
+          "tsType": "Decimal128",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": 0,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "late_return_fee_per_hour",
+          "dbmlType": "decimal(10,2)",
+          "tsType": "Decimal128",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "mileage_limit_per_day",
+          "dbmlType": "integer",
+          "tsType": "number",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": "km per day included",
+          "enumName": null
+        },
+        {
+          "name": "excess_mileage_fee",
+          "dbmlType": "decimal(10,2)",
+          "tsType": "Decimal128",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": "fee per km over limit",
+          "enumName": null
+        }
+      ],
+      "indexes": [
+        {
+          "name": "ux_pricings_vehicle_effective_from",
+          "type": null,
+          "unique": true,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "vehicle_id",
+            "effective_from"
+          ]
+        }
+      ],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "vehicles",
+          "sourceFields": [
+            "vehicle_id"
+          ],
+          "targetFields": [
+            "vehicle_id"
+          ],
+          "onDelete": "cascade"
+        }
+      ]
+    },
+    "rentals": {
+      "tableName": "rentals",
+      "collectionName": "rentals",
+      "note": null,
+      "fields": [
+        {
+          "name": "rental_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": true,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "booking_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "vehicle_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "pickup_datetime",
+          "dbmlType": "datetime",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "expected_return_datetime",
+          "dbmlType": "datetime",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "actual_return_datetime",
+          "dbmlType": "datetime",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "status",
+          "dbmlType": "rental_status",
+          "tsType": "enum:rental_status",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "reserved",
+          "note": null,
+          "enumName": "rental_status"
+        },
+        {
+          "name": "score",
+          "dbmlType": "INT",
+          "tsType": "number",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "comment",
+          "dbmlType": "VARCHAR(2000)",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "rated_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [
+        {
+          "name": "ix_rentals_vehicle",
+          "type": null,
+          "unique": false,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "vehicle_id"
+          ]
+        }
+      ],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "bookings",
+          "sourceFields": [
+            "booking_id"
+          ],
+          "targetFields": [
+            "booking_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "belongsTo",
+          "targetCollection": "vehicles",
+          "sourceFields": [
+            "vehicle_id"
+          ],
+          "targetFields": [
+            "vehicle_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "hasOne",
+          "targetCollection": "contracts",
+          "sourceFields": [
+            "rental_id"
+          ],
+          "targetFields": [
+            "rental_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "inspections",
+          "sourceFields": [
+            "rental_id"
+          ],
+          "targetFields": [
+            "rental_id"
+          ],
+          "onDelete": "cascade"
+        }
+      ]
+    },
+    "renters": {
+      "tableName": "renters",
+      "collectionName": "renters",
+      "note": null,
+      "fields": [
+        {
+          "name": "user_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "driver_license_no",
+          "dbmlType": "VARCHAR(64)",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "date_of_birth",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "address",
+          "dbmlType": "VARCHAR(500)",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "risk_score",
+          "dbmlType": "integer",
+          "tsType": "number",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": 0,
+          "note": "0-100, higher = riskier",
+          "enumName": null
+        }
+      ],
+      "indexes": [],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "users",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "bookings",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "renter_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "kycs",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "renter_id"
+          ],
+          "onDelete": "cascade"
+        }
+      ]
+    },
+    "reports": {
+      "tableName": "reports",
+      "collectionName": "reports",
+      "note": null,
+      "fields": [
+        {
+          "name": "report_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": true,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "inspection_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "notes",
+          "dbmlType": "VARCHAR(2000)",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "damage_found",
+          "dbmlType": "BOOLEAN",
+          "tsType": "boolean",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": false,
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [
+        {
+          "name": "ix_reports_inspection",
+          "type": null,
+          "unique": false,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "inspection_id"
+          ]
+        }
+      ],
+      "relations": [
+        {
+          "type": "hasMany",
+          "targetCollection": "reports_photo",
+          "sourceFields": [
+            "report_id"
+          ],
+          "targetFields": [
+            "report_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "belongsTo",
+          "targetCollection": "inspections",
+          "sourceFields": [
+            "inspection_id"
+          ],
+          "targetFields": [
+            "inspection_id"
+          ],
+          "onDelete": "cascade"
+        }
+      ]
+    },
+    "reports_photo": {
+      "tableName": "reports_photo",
+      "collectionName": "reports_photo",
+      "note": null,
+      "fields": [
+        {
+          "name": "reports_photo_id",
+          "dbmlType": "UNIQUEIDENTIFIER",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": false,
+          "default": "NEWSEQUENTIALID()",
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "report_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "inspection_id",
+          "dbmlType": "UNIQUEIDENTIFIER",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "url",
+          "dbmlType": "NVARCHAR(500)",
+          "tsType": "string",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "label",
+          "dbmlType": "NVARCHAR(200)",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "created_at",
+          "dbmlType": "datetime2(3)",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "SYSUTCDATETIME()",
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "reports",
+          "sourceFields": [
+            "report_id"
+          ],
+          "targetFields": [
+            "report_id"
+          ],
+          "onDelete": null
+        }
+      ]
+    },
+    "signatures": {
+      "tableName": "signatures",
+      "collectionName": "signatures",
+      "note": null,
+      "fields": [
+        {
+          "name": "signature_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": true,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "contract_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "role",
+          "dbmlType": "party_role",
+          "tsType": "enum:party_role",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": "party_role"
+        },
+        {
+          "name": "signature_event",
+          "dbmlType": "signature_event_type",
+          "tsType": "enum:signature_event_type",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": "signature_event_type"
+        },
+        {
+          "name": "type",
+          "dbmlType": "signature_type",
+          "tsType": "enum:signature_type",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "digital_cert",
+          "note": null,
+          "enumName": "signature_type"
+        },
+        {
+          "name": "signed_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "signer_ip",
+          "dbmlType": "INET",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "user_agent",
+          "dbmlType": "TEXT",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "provider_signature_id",
+          "dbmlType": "TEXT",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "signature_image_url",
+          "dbmlType": "TEXT",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "cert_subject",
+          "dbmlType": "TEXT",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "cert_issuer",
+          "dbmlType": "TEXT",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "cert_serial",
+          "dbmlType": "TEXT",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "cert_fingerprint_sha256",
+          "dbmlType": "TEXT",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "signature_hash",
+          "dbmlType": "TEXT",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "evidence_url",
+          "dbmlType": "TEXT",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [
+        {
+          "name": "ix_signatures_contract",
+          "type": null,
+          "unique": false,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "contract_id"
+          ]
+        }
+      ],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "contracts",
+          "sourceFields": [
+            "contract_id"
+          ],
+          "targetFields": [
+            "contract_id"
+          ],
+          "onDelete": "cascade"
+        }
+      ]
+    },
+    "staff": {
+      "tableName": "staff",
+      "collectionName": "staff",
+      "note": null,
+      "fields": [
+        {
+          "name": "user_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "employee_code",
+          "dbmlType": "VARCHAR(50)",
+          "tsType": "string",
+          "required": true,
+          "unique": true,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "position",
+          "dbmlType": "VARCHAR(100)",
+          "tsType": "string",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "hire_date",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "users",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "staff_at_stations",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "staff_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "bookings",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "verified_by_staff_id"
+          ],
+          "onDelete": "set null"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "inspections",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "inspector_staff_id"
+          ],
+          "onDelete": "set null"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "staff_transfers",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "staff_id"
+          ],
+          "onDelete": null
+        }
+      ]
+    },
+    "staff_at_stations": {
+      "tableName": "staff_at_stations",
+      "collectionName": "staff_at_stations",
+      "note": null,
+      "fields": [
+        {
+          "name": "staff_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "start_time",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "station_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "end_time",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "role_at_station",
+          "dbmlType": "VARCHAR(100)",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [
+        {
+          "name": null,
+          "type": null,
+          "unique": true,
+          "primaryKey": true,
+          "note": null,
+          "columns": [
+            "staff_id",
+            "start_time"
+          ]
+        },
+        {
+          "name": "ix_staff_at_stations_staff_endtime",
+          "type": null,
+          "unique": false,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "staff_id",
+            "end_time"
+          ]
+        },
+        {
+          "name": "ix_staff_at_stations_station_endtime",
+          "type": null,
+          "unique": false,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "station_id",
+            "end_time"
+          ]
+        }
+      ],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "staff",
+          "sourceFields": [
+            "staff_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "belongsTo",
+          "targetCollection": "stations",
+          "sourceFields": [
+            "station_id"
+          ],
+          "targetFields": [
+            "station_id"
+          ],
+          "onDelete": "cascade"
+        }
+      ]
+    },
+    "staff_transfers": {
+      "tableName": "staff_transfers",
+      "collectionName": "staff_transfers",
+      "note": null,
+      "fields": [
+        {
+          "name": "staff_transfer_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": true,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "staff_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "from_station_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "to_station_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "approved_by_admin_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "created_by_admin_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "created_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "approved_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "effective_from",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "status",
+          "dbmlType": "transfer_status",
+          "tsType": "enum:transfer_status",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "draft",
+          "note": null,
+          "enumName": "transfer_status"
+        },
+        {
+          "name": "notes",
+          "dbmlType": "VARCHAR(1000)",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [
+        {
+          "name": "ix_staff_transfers_staff_status",
+          "type": null,
+          "unique": false,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "staff_id",
+            "status"
+          ]
+        },
+        {
+          "name": "ix_staff_transfers_to_station",
+          "type": null,
+          "unique": false,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "to_station_id"
+          ]
+        }
+      ],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "staff",
+          "sourceFields": [
+            "staff_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "belongsTo",
+          "targetCollection": "stations",
+          "sourceFields": [
+            "from_station_id"
+          ],
+          "targetFields": [
+            "station_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "belongsTo",
+          "targetCollection": "stations",
+          "sourceFields": [
+            "to_station_id"
+          ],
+          "targetFields": [
+            "station_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "belongsTo",
+          "targetCollection": "admins",
+          "sourceFields": [
+            "created_by_admin_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "belongsTo",
+          "targetCollection": "admins",
+          "sourceFields": [
+            "approved_by_admin_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": null
+        }
+      ]
+    },
+    "stations": {
+      "tableName": "stations",
+      "collectionName": "stations",
+      "note": null,
+      "fields": [
+        {
+          "name": "station_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": true,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "name",
+          "dbmlType": "VARCHAR(150)",
+          "tsType": "string",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "address",
+          "dbmlType": "VARCHAR(500)",
+          "tsType": "string",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "latitude",
+          "dbmlType": "DOUBLEPRECISION",
+          "tsType": "number",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "longitude",
+          "dbmlType": "DOUBLEPRECISION",
+          "tsType": "number",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [],
+      "relations": [
+        {
+          "type": "hasMany",
+          "targetCollection": "staff_at_stations",
+          "sourceFields": [
+            "station_id"
+          ],
+          "targetFields": [
+            "station_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "vehicle_at_stations",
+          "sourceFields": [
+            "station_id"
+          ],
+          "targetFields": [
+            "station_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "vehicle_transfers",
+          "sourceFields": [
+            "station_id"
+          ],
+          "targetFields": [
+            "from_station_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "vehicle_transfers",
+          "sourceFields": [
+            "station_id"
+          ],
+          "targetFields": [
+            "to_station_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "staff_transfers",
+          "sourceFields": [
+            "station_id"
+          ],
+          "targetFields": [
+            "from_station_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "staff_transfers",
+          "sourceFields": [
+            "station_id"
+          ],
+          "targetFields": [
+            "to_station_id"
+          ],
+          "onDelete": null
+        }
+      ]
+    },
+    "users": {
+      "tableName": "users",
+      "collectionName": "users",
+      "note": null,
+      "fields": [
+        {
+          "name": "user_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": true,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "role",
+          "dbmlType": "user_role",
+          "tsType": "enum:user_role",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "unknown",
+          "note": null,
+          "enumName": "user_role"
+        },
+        {
+          "name": "email",
+          "dbmlType": "VARCHAR(255)",
+          "tsType": "string",
+          "required": true,
+          "unique": true,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "password_hash",
+          "dbmlType": "VARCHAR(255)",
+          "tsType": "string",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "full_name",
+          "dbmlType": "VARCHAR(200)",
+          "tsType": "string",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "phone",
+          "dbmlType": "VARCHAR(50)",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "created_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [],
+      "relations": [
+        {
+          "type": "hasMany",
+          "targetCollection": "renters",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "staff",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "admins",
+          "sourceFields": [
+            "user_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": "cascade"
+        }
+      ]
+    },
+    "vehicle_at_stations": {
+      "tableName": "vehicle_at_stations",
+      "collectionName": "vehicle_at_stations",
+      "note": null,
+      "fields": [
+        {
+          "name": "vehicle_at_station_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": true,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "vehicle_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "station_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "start_time",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "end_time",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "current_battery_capacity_kwh",
+          "dbmlType": "DOUBLEPRECISION",
+          "tsType": "number",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "current_mileage",
+          "dbmlType": "integer",
+          "tsType": "number",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "status",
+          "dbmlType": "vehicle_at_stations_status_t",
+          "tsType": "enum:vehicle_at_stations_status_t",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": "vehicle_at_stations_status_t"
+        }
+      ],
+      "indexes": [
+        {
+          "name": "ux_vehicle_at_stations_vehicle_start",
+          "type": null,
+          "unique": true,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "vehicle_id",
+            "start_time"
+          ]
+        },
+        {
+          "name": "ix_vehicle_at_stations_vehicle_end",
+          "type": null,
+          "unique": false,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "vehicle_id",
+            "end_time"
+          ]
+        },
+        {
+          "name": "ix_vehicle_at_stations_station_end",
+          "type": null,
+          "unique": false,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "station_id",
+            "end_time"
+          ]
+        }
+      ],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "vehicles",
+          "sourceFields": [
+            "vehicle_id"
+          ],
+          "targetFields": [
+            "vehicle_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "belongsTo",
+          "targetCollection": "stations",
+          "sourceFields": [
+            "station_id"
+          ],
+          "targetFields": [
+            "station_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "bookings",
+          "sourceFields": [
+            "vehicle_at_station_id"
+          ],
+          "targetFields": [
+            "vehicle_at_station_id"
+          ],
+          "onDelete": null
+        }
+      ]
+    },
+    "vehicle_transfers": {
+      "tableName": "vehicle_transfers",
+      "collectionName": "vehicle_transfers",
+      "note": null,
+      "fields": [
+        {
+          "name": "vehicle_transfer_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": true,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "vehicle_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "from_station_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "to_station_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "picked_up_by_staff_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "picked_up_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "dropped_off_by_staff_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "dropped_off_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "pickup_notes",
+          "dbmlType": "VARCHAR(1000)",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "dropoff_notes",
+          "dbmlType": "VARCHAR(1000)",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "approved_by_admin_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "created_by_admin_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "created_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "Date.now",
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "approved_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "scheduled_pickup_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "scheduled_dropoff_at",
+          "dbmlType": "timestamptz",
+          "tsType": "Date",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "status",
+          "dbmlType": "transfer_status",
+          "tsType": "enum:transfer_status",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "draft",
+          "note": null,
+          "enumName": "transfer_status"
+        },
+        {
+          "name": "notes",
+          "dbmlType": "VARCHAR(1000)",
+          "tsType": "string",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        }
+      ],
+      "indexes": [
+        {
+          "name": "ix_vehicle_transfers_status",
+          "type": null,
+          "unique": false,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "status"
+          ]
+        },
+        {
+          "name": "ix_vehicle_transfers_from_to",
+          "type": null,
+          "unique": false,
+          "primaryKey": false,
+          "note": null,
+          "columns": [
+            "from_station_id",
+            "to_station_id"
+          ]
+        }
+      ],
+      "relations": [
+        {
+          "type": "belongsTo",
+          "targetCollection": "stations",
+          "sourceFields": [
+            "from_station_id"
+          ],
+          "targetFields": [
+            "station_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "belongsTo",
+          "targetCollection": "stations",
+          "sourceFields": [
+            "to_station_id"
+          ],
+          "targetFields": [
+            "station_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "belongsTo",
+          "targetCollection": "admins",
+          "sourceFields": [
+            "created_by_admin_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "belongsTo",
+          "targetCollection": "admins",
+          "sourceFields": [
+            "approved_by_admin_id"
+          ],
+          "targetFields": [
+            "user_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "belongsTo",
+          "targetCollection": "vehicles",
+          "sourceFields": [
+            "vehicle_id"
+          ],
+          "targetFields": [
+            "vehicle_id"
+          ],
+          "onDelete": null
+        }
+      ]
+    },
+    "vehicles": {
+      "tableName": "vehicles",
+      "collectionName": "vehicles",
+      "note": null,
+      "fields": [
+        {
+          "name": "vehicle_id",
+          "dbmlType": "INT",
+          "tsType": "Types.ObjectId",
+          "required": true,
+          "unique": true,
+          "primaryKey": true,
+          "autoIncrement": true,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "make",
+          "dbmlType": "VARCHAR(100)",
+          "tsType": "string",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "model",
+          "dbmlType": "VARCHAR(100)",
+          "tsType": "string",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "model_year",
+          "dbmlType": "INT",
+          "tsType": "number",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "category",
+          "dbmlType": "VARCHAR(50)",
+          "tsType": "string",
+          "required": true,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": "EV",
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "battery_capacity_kwh",
+          "dbmlType": "DOUBLEPRECISION",
+          "tsType": "number",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "range_km",
+          "dbmlType": "DOUBLEPRECISION",
+          "tsType": "number",
+          "required": false,
+          "unique": false,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": null,
+          "enumName": null
+        },
+        {
+          "name": "vin_number",
+          "dbmlType": "varchar(50)",
+          "tsType": "string",
+          "required": false,
+          "unique": true,
+          "primaryKey": false,
+          "autoIncrement": false,
+          "default": null,
+          "note": "Vehicle Identification Number",
+          "enumName": null
+        }
+      ],
+      "indexes": [],
+      "relations": [
+        {
+          "type": "hasMany",
+          "targetCollection": "vehicle_at_stations",
+          "sourceFields": [
+            "vehicle_id"
+          ],
+          "targetFields": [
+            "vehicle_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "rentals",
+          "sourceFields": [
+            "vehicle_id"
+          ],
+          "targetFields": [
+            "vehicle_id"
+          ],
+          "onDelete": null
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "pricings",
+          "sourceFields": [
+            "vehicle_id"
+          ],
+          "targetFields": [
+            "vehicle_id"
+          ],
+          "onDelete": "cascade"
+        },
+        {
+          "type": "hasMany",
+          "targetCollection": "vehicle_transfers",
+          "sourceFields": [
+            "vehicle_id"
+          ],
+          "targetFields": [
+            "vehicle_id"
+          ],
+          "onDelete": null
+        }
+      ]
+    }
+  }
+}

--- a/docs/model-spec.yml
+++ b/docs/model-spec.yml
@@ -1,0 +1,2615 @@
+source: DB.dbml
+generatedAt: "2025-10-09T19:07:36.156Z"
+fixes: []
+enums:
+  booking_status:
+    name: booking_status
+    values: [pending_verification, verified, cancelled]
+  booking_verification_status:
+    name: booking_verification_status
+    values: [pending, approved, rejected_mismatch, rejected_other]
+  confirmation_type:
+    name: confirmation_type
+    values: [pickup, dropoff]
+  contract_status:
+    name: contract_status
+    values: [issued, partially_signed, signed, voided, expired]
+  esign_provider:
+    name: esign_provider
+    values: [native, docusign, adobesign, signnow, other]
+  fee_type:
+    name: fee_type
+    values: [deposit, rental_charge, surcharge, damage, other]
+  inspection_type:
+    name: inspection_type
+    values: [pre_rental, post_rental]
+  kyc_status:
+    name: kyc_status
+    values: [submitted, approved, rejected, expired]
+  kyc_type:
+    name: kyc_type
+    values: [national_id, driver_license, passport, other]
+  party_role:
+    name: party_role
+    values: [renter, staff, other]
+  payment_method:
+    name: payment_method
+    values: [unknown, cash, card, ewallet, bank_transfer]
+  payment_status:
+    name: payment_status
+    values: [paid, refunded]
+  rental_status:
+    name: rental_status
+    values: [reserved, in_progress, completed, late, cancelled]
+  signature_event_type:
+    name: signature_event_type
+    values: [pickup, dropoff]
+  signature_type:
+    name: signature_type
+    values: [drawn, typed, digital_cert]
+  transfer_status:
+    name: transfer_status
+    values: [draft, approved, in_transit, completed, cancelled]
+  user_role:
+    name: user_role
+    values: [unknown, renter, staff, admin]
+  vehicle_at_stations_status_t:
+    name: vehicle_at_stations_status_t
+    values: [maintain, available, booked]
+collections:
+  admins:
+    tableName: admins
+    collectionName: admins
+    note: null
+    fields:
+      -
+        name: user_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: title
+        dbmlType: "VARCHAR(100)"
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: notes
+        dbmlType: "VARCHAR(500)"
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: hire_date
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+    indexes: []
+    relations:
+      -
+        type: belongsTo
+        targetCollection: users
+        sourceFields: [user_id]
+        targetFields: [user_id]
+        onDelete: cascade
+      -
+        type: hasMany
+        targetCollection: vehicle_transfers
+        sourceFields: [user_id]
+        targetFields: [created_by_admin_id]
+        onDelete: null
+      -
+        type: hasMany
+        targetCollection: vehicle_transfers
+        sourceFields: [user_id]
+        targetFields: [approved_by_admin_id]
+        onDelete: null
+      -
+        type: hasMany
+        targetCollection: staff_transfers
+        sourceFields: [user_id]
+        targetFields: [created_by_admin_id]
+        onDelete: null
+      -
+        type: hasMany
+        targetCollection: staff_transfers
+        sourceFields: [user_id]
+        targetFields: [approved_by_admin_id]
+        onDelete: null
+  bookings:
+    tableName: bookings
+    collectionName: bookings
+    note: null
+    fields:
+      -
+        name: booking_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: true
+        default: null
+        note: null
+        enumName: null
+      -
+        name: renter_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: vehicle_at_station_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: booking_created_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+      -
+        name: expected_return_datetime
+        dbmlType: datetime
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: status
+        dbmlType: booking_status
+        tsType: "enum:booking_status"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: pending_verification
+        note: null
+        enumName: booking_status
+      -
+        name: verification_status
+        dbmlType: booking_verification_status
+        tsType: "enum:booking_verification_status"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: pending
+        note: null
+        enumName: booking_verification_status
+      -
+        name: verified_by_staff_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: verified_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: cancel_reason
+        dbmlType: "VARCHAR(1000)"
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+    indexes:
+      -
+        name: ix_bookings_renter
+        type: null
+        unique: false
+        primaryKey: false
+        note: null
+        columns: [renter_id]
+      -
+        name: ix_bookings_vehicle_at_station
+        type: null
+        unique: false
+        primaryKey: false
+        note: null
+        columns: [vehicle_at_station_id]
+    relations:
+      -
+        type: belongsTo
+        targetCollection: renters
+        sourceFields: [renter_id]
+        targetFields: [user_id]
+        onDelete: null
+      -
+        type: belongsTo
+        targetCollection: vehicle_at_stations
+        sourceFields: [vehicle_at_station_id]
+        targetFields: [vehicle_at_station_id]
+        onDelete: null
+      -
+        type: belongsTo
+        targetCollection: staff
+        sourceFields: [verified_by_staff_id]
+        targetFields: [user_id]
+        onDelete: "set null"
+      -
+        type: hasMany
+        targetCollection: fees
+        sourceFields: [booking_id]
+        targetFields: [booking_id]
+        onDelete: cascade
+      -
+        type: hasMany
+        targetCollection: rentals
+        sourceFields: [booking_id]
+        targetFields: [booking_id]
+        onDelete: cascade
+  contracts:
+    tableName: contracts
+    collectionName: contracts
+    note: null
+    fields:
+      -
+        name: contract_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: true
+        default: null
+        note: null
+        enumName: null
+      -
+        name: rental_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: version
+        dbmlType: INT
+        tsType: number
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: 1
+        note: null
+        enumName: null
+      -
+        name: status
+        dbmlType: contract_status
+        tsType: "enum:contract_status"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: issued
+        note: null
+        enumName: contract_status
+      -
+        name: issued_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+      -
+        name: completed_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: provider
+        dbmlType: esign_provider
+        tsType: "enum:esign_provider"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: native
+        note: null
+        enumName: esign_provider
+      -
+        name: provider_envelope_id
+        dbmlType: TEXT
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: document_url
+        dbmlType: TEXT
+        tsType: string
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: document_hash
+        dbmlType: TEXT
+        tsType: string
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: ltv_enabled
+        dbmlType: BOOLEAN
+        tsType: boolean
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: false
+        note: null
+        enumName: null
+      -
+        name: audit_trail_url
+        dbmlType: TEXT
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: updated_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+    indexes: []
+    relations:
+      -
+        type: hasOne
+        targetCollection: rentals
+        sourceFields: [rental_id]
+        targetFields: [rental_id]
+        onDelete: cascade
+      -
+        type: hasMany
+        targetCollection: signatures
+        sourceFields: [contract_id]
+        targetFields: [contract_id]
+        onDelete: cascade
+  fees:
+    tableName: fees
+    collectionName: fees
+    note: null
+    fields:
+      -
+        name: fee_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: true
+        default: null
+        note: null
+        enumName: null
+      -
+        name: booking_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: type
+        dbmlType: fee_type
+        tsType: "enum:fee_type"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: deposit
+        note: null
+        enumName: fee_type
+      -
+        name: description
+        dbmlType: "VARCHAR(200)"
+        tsType: string
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: amount
+        dbmlType: "NUMERIC(18,2)"
+        tsType: Decimal128
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: currency
+        dbmlType: "VARCHAR(10)"
+        tsType: string
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: USD
+        note: null
+        enumName: null
+      -
+        name: created_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+    indexes:
+      -
+        name: ux_fees_deposit_per_booking
+        type: null
+        unique: true
+        primaryKey: false
+        note: null
+        columns: [booking_id]
+    relations:
+      -
+        type: belongsTo
+        targetCollection: bookings
+        sourceFields: [booking_id]
+        targetFields: [booking_id]
+        onDelete: cascade
+      -
+        type: hasMany
+        targetCollection: payments
+        sourceFields: [fee_id]
+        targetFields: [payment_id]
+        onDelete: cascade
+  inspections:
+    tableName: inspections
+    collectionName: inspections
+    note: null
+    fields:
+      -
+        name: inspection_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: true
+        default: null
+        note: null
+        enumName: null
+      -
+        name: rental_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: type
+        dbmlType: inspection_type
+        tsType: "enum:inspection_type"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: pre_rental
+        note: null
+        enumName: inspection_type
+      -
+        name: inspected_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+      -
+        name: inspector_staff_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: current_battery_capacity_kwh
+        dbmlType: DOUBLEPRECISION
+        tsType: number
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: current_mileage
+        dbmlType: integer
+        tsType: number
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+    indexes:
+      -
+        name: ux_inspections_rental_type
+        type: null
+        unique: true
+        primaryKey: false
+        note: null
+        columns: [rental_id, type]
+    relations:
+      -
+        type: belongsTo
+        targetCollection: rentals
+        sourceFields: [rental_id]
+        targetFields: [rental_id]
+        onDelete: cascade
+      -
+        type: belongsTo
+        targetCollection: staff
+        sourceFields: [inspector_staff_id]
+        targetFields: [user_id]
+        onDelete: "set null"
+      -
+        type: hasMany
+        targetCollection: reports
+        sourceFields: [inspection_id]
+        targetFields: [inspection_id]
+        onDelete: cascade
+  kycs:
+    tableName: kycs
+    collectionName: kycs
+    note: null
+    fields:
+      -
+        name: kyc_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: true
+        default: null
+        note: null
+        enumName: null
+      -
+        name: renter_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: type
+        dbmlType: kyc_type
+        tsType: "enum:kyc_type"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: driver_license
+        note: null
+        enumName: kyc_type
+      -
+        name: document_number
+        dbmlType: "VARCHAR(100)"
+        tsType: string
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: expiry_date
+        dbmlType: timestamptz
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: status
+        dbmlType: kyc_status
+        tsType: "enum:kyc_status"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: submitted
+        note: null
+        enumName: kyc_status
+      -
+        name: submitted_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+      -
+        name: verified_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+    indexes:
+      -
+        name: ix_kycs_renter
+        type: null
+        unique: false
+        primaryKey: false
+        note: null
+        columns: [renter_id]
+    relations:
+      -
+        type: belongsTo
+        targetCollection: renters
+        sourceFields: [renter_id]
+        targetFields: [user_id]
+        onDelete: cascade
+  payments:
+    tableName: payments
+    collectionName: payments
+    note: null
+    fields:
+      -
+        name: payment_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: method
+        dbmlType: payment_method
+        tsType: "enum:payment_method"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: unknown
+        note: null
+        enumName: payment_method
+      -
+        name: status
+        dbmlType: payment_status
+        tsType: "enum:payment_status"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: paid
+        note: null
+        enumName: payment_status
+      -
+        name: amount_paid
+        dbmlType: "NUMERIC(18,2)"
+        tsType: Decimal128
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: paid_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+      -
+        name: provider_reference
+        dbmlType: "VARCHAR(200)"
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+    indexes: []
+    relations:
+      -
+        type: belongsTo
+        targetCollection: fees
+        sourceFields: [payment_id]
+        targetFields: [fee_id]
+        onDelete: cascade
+  pricings:
+    tableName: pricings
+    collectionName: pricings
+    note: null
+    fields:
+      -
+        name: pricing_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: true
+        default: null
+        note: null
+        enumName: null
+      -
+        name: vehicle_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: price_per_hour
+        dbmlType: "NUMERIC(18,2)"
+        tsType: Decimal128
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: price_per_day
+        dbmlType: "NUMERIC(18,2)"
+        tsType: Decimal128
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: effective_from
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: effective_to
+        dbmlType: timestamptz
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: deposit_amount
+        dbmlType: "decimal(10,2)"
+        tsType: Decimal128
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: 0
+        note: null
+        enumName: null
+      -
+        name: late_return_fee_per_hour
+        dbmlType: "decimal(10,2)"
+        tsType: Decimal128
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: mileage_limit_per_day
+        dbmlType: integer
+        tsType: number
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: "km per day included"
+        enumName: null
+      -
+        name: excess_mileage_fee
+        dbmlType: "decimal(10,2)"
+        tsType: Decimal128
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: "fee per km over limit"
+        enumName: null
+    indexes:
+      -
+        name: ux_pricings_vehicle_effective_from
+        type: null
+        unique: true
+        primaryKey: false
+        note: null
+        columns: [vehicle_id, effective_from]
+    relations:
+      -
+        type: belongsTo
+        targetCollection: vehicles
+        sourceFields: [vehicle_id]
+        targetFields: [vehicle_id]
+        onDelete: cascade
+  rentals:
+    tableName: rentals
+    collectionName: rentals
+    note: null
+    fields:
+      -
+        name: rental_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: true
+        default: null
+        note: null
+        enumName: null
+      -
+        name: booking_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: vehicle_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: pickup_datetime
+        dbmlType: datetime
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: expected_return_datetime
+        dbmlType: datetime
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: actual_return_datetime
+        dbmlType: datetime
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: status
+        dbmlType: rental_status
+        tsType: "enum:rental_status"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: reserved
+        note: null
+        enumName: rental_status
+      -
+        name: score
+        dbmlType: INT
+        tsType: number
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: comment
+        dbmlType: "VARCHAR(2000)"
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: rated_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+    indexes:
+      -
+        name: ix_rentals_vehicle
+        type: null
+        unique: false
+        primaryKey: false
+        note: null
+        columns: [vehicle_id]
+    relations:
+      -
+        type: belongsTo
+        targetCollection: bookings
+        sourceFields: [booking_id]
+        targetFields: [booking_id]
+        onDelete: cascade
+      -
+        type: belongsTo
+        targetCollection: vehicles
+        sourceFields: [vehicle_id]
+        targetFields: [vehicle_id]
+        onDelete: null
+      -
+        type: hasOne
+        targetCollection: contracts
+        sourceFields: [rental_id]
+        targetFields: [rental_id]
+        onDelete: cascade
+      -
+        type: hasMany
+        targetCollection: inspections
+        sourceFields: [rental_id]
+        targetFields: [rental_id]
+        onDelete: cascade
+  renters:
+    tableName: renters
+    collectionName: renters
+    note: null
+    fields:
+      -
+        name: user_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: driver_license_no
+        dbmlType: "VARCHAR(64)"
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: date_of_birth
+        dbmlType: timestamptz
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: address
+        dbmlType: "VARCHAR(500)"
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: risk_score
+        dbmlType: integer
+        tsType: number
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: 0
+        note: "0-100, higher = riskier"
+        enumName: null
+    indexes: []
+    relations:
+      -
+        type: belongsTo
+        targetCollection: users
+        sourceFields: [user_id]
+        targetFields: [user_id]
+        onDelete: cascade
+      -
+        type: hasMany
+        targetCollection: bookings
+        sourceFields: [user_id]
+        targetFields: [renter_id]
+        onDelete: null
+      -
+        type: hasMany
+        targetCollection: kycs
+        sourceFields: [user_id]
+        targetFields: [renter_id]
+        onDelete: cascade
+  reports:
+    tableName: reports
+    collectionName: reports
+    note: null
+    fields:
+      -
+        name: report_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: true
+        default: null
+        note: null
+        enumName: null
+      -
+        name: inspection_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: notes
+        dbmlType: "VARCHAR(2000)"
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: damage_found
+        dbmlType: BOOLEAN
+        tsType: boolean
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: false
+        note: null
+        enumName: null
+    indexes:
+      -
+        name: ix_reports_inspection
+        type: null
+        unique: false
+        primaryKey: false
+        note: null
+        columns: [inspection_id]
+    relations:
+      -
+        type: hasMany
+        targetCollection: reports_photo
+        sourceFields: [report_id]
+        targetFields: [report_id]
+        onDelete: null
+      -
+        type: belongsTo
+        targetCollection: inspections
+        sourceFields: [inspection_id]
+        targetFields: [inspection_id]
+        onDelete: cascade
+  reports_photo:
+    tableName: reports_photo
+    collectionName: reports_photo
+    note: null
+    fields:
+      -
+        name: reports_photo_id
+        dbmlType: UNIQUEIDENTIFIER
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: false
+        default: "NEWSEQUENTIALID()"
+        note: null
+        enumName: null
+      -
+        name: report_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: inspection_id
+        dbmlType: UNIQUEIDENTIFIER
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: url
+        dbmlType: "NVARCHAR(500)"
+        tsType: string
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: label
+        dbmlType: "NVARCHAR(200)"
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: created_at
+        dbmlType: "datetime2(3)"
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: "SYSUTCDATETIME()"
+        note: null
+        enumName: null
+    indexes: []
+    relations:
+      -
+        type: belongsTo
+        targetCollection: reports
+        sourceFields: [report_id]
+        targetFields: [report_id]
+        onDelete: null
+  signatures:
+    tableName: signatures
+    collectionName: signatures
+    note: null
+    fields:
+      -
+        name: signature_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: true
+        default: null
+        note: null
+        enumName: null
+      -
+        name: contract_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: role
+        dbmlType: party_role
+        tsType: "enum:party_role"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: party_role
+      -
+        name: signature_event
+        dbmlType: signature_event_type
+        tsType: "enum:signature_event_type"
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: signature_event_type
+      -
+        name: type
+        dbmlType: signature_type
+        tsType: "enum:signature_type"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: digital_cert
+        note: null
+        enumName: signature_type
+      -
+        name: signed_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+      -
+        name: signer_ip
+        dbmlType: INET
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: user_agent
+        dbmlType: TEXT
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: provider_signature_id
+        dbmlType: TEXT
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: signature_image_url
+        dbmlType: TEXT
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: cert_subject
+        dbmlType: TEXT
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: cert_issuer
+        dbmlType: TEXT
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: cert_serial
+        dbmlType: TEXT
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: cert_fingerprint_sha256
+        dbmlType: TEXT
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: signature_hash
+        dbmlType: TEXT
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: evidence_url
+        dbmlType: TEXT
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+    indexes:
+      -
+        name: ix_signatures_contract
+        type: null
+        unique: false
+        primaryKey: false
+        note: null
+        columns: [contract_id]
+    relations:
+      -
+        type: belongsTo
+        targetCollection: contracts
+        sourceFields: [contract_id]
+        targetFields: [contract_id]
+        onDelete: cascade
+  staff:
+    tableName: staff
+    collectionName: staff
+    note: null
+    fields:
+      -
+        name: user_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: employee_code
+        dbmlType: "VARCHAR(50)"
+        tsType: string
+        required: true
+        unique: true
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: position
+        dbmlType: "VARCHAR(100)"
+        tsType: string
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: hire_date
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+    indexes: []
+    relations:
+      -
+        type: belongsTo
+        targetCollection: users
+        sourceFields: [user_id]
+        targetFields: [user_id]
+        onDelete: cascade
+      -
+        type: hasMany
+        targetCollection: staff_at_stations
+        sourceFields: [user_id]
+        targetFields: [staff_id]
+        onDelete: cascade
+      -
+        type: hasMany
+        targetCollection: bookings
+        sourceFields: [user_id]
+        targetFields: [verified_by_staff_id]
+        onDelete: "set null"
+      -
+        type: hasMany
+        targetCollection: inspections
+        sourceFields: [user_id]
+        targetFields: [inspector_staff_id]
+        onDelete: "set null"
+      -
+        type: hasMany
+        targetCollection: staff_transfers
+        sourceFields: [user_id]
+        targetFields: [staff_id]
+        onDelete: null
+  staff_at_stations:
+    tableName: staff_at_stations
+    collectionName: staff_at_stations
+    note: null
+    fields:
+      -
+        name: staff_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: start_time
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+      -
+        name: station_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: end_time
+        dbmlType: timestamptz
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: role_at_station
+        dbmlType: "VARCHAR(100)"
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+    indexes:
+      -
+        name: null
+        type: null
+        unique: true
+        primaryKey: true
+        note: null
+        columns: [staff_id, start_time]
+      -
+        name: ix_staff_at_stations_staff_endtime
+        type: null
+        unique: false
+        primaryKey: false
+        note: null
+        columns: [staff_id, end_time]
+      -
+        name: ix_staff_at_stations_station_endtime
+        type: null
+        unique: false
+        primaryKey: false
+        note: null
+        columns: [station_id, end_time]
+    relations:
+      -
+        type: belongsTo
+        targetCollection: staff
+        sourceFields: [staff_id]
+        targetFields: [user_id]
+        onDelete: cascade
+      -
+        type: belongsTo
+        targetCollection: stations
+        sourceFields: [station_id]
+        targetFields: [station_id]
+        onDelete: cascade
+  staff_transfers:
+    tableName: staff_transfers
+    collectionName: staff_transfers
+    note: null
+    fields:
+      -
+        name: staff_transfer_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: true
+        default: null
+        note: null
+        enumName: null
+      -
+        name: staff_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: from_station_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: to_station_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: approved_by_admin_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: created_by_admin_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: created_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+      -
+        name: approved_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: effective_from
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: status
+        dbmlType: transfer_status
+        tsType: "enum:transfer_status"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: draft
+        note: null
+        enumName: transfer_status
+      -
+        name: notes
+        dbmlType: "VARCHAR(1000)"
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+    indexes:
+      -
+        name: ix_staff_transfers_staff_status
+        type: null
+        unique: false
+        primaryKey: false
+        note: null
+        columns: [staff_id, status]
+      -
+        name: ix_staff_transfers_to_station
+        type: null
+        unique: false
+        primaryKey: false
+        note: null
+        columns: [to_station_id]
+    relations:
+      -
+        type: belongsTo
+        targetCollection: staff
+        sourceFields: [staff_id]
+        targetFields: [user_id]
+        onDelete: null
+      -
+        type: belongsTo
+        targetCollection: stations
+        sourceFields: [from_station_id]
+        targetFields: [station_id]
+        onDelete: null
+      -
+        type: belongsTo
+        targetCollection: stations
+        sourceFields: [to_station_id]
+        targetFields: [station_id]
+        onDelete: null
+      -
+        type: belongsTo
+        targetCollection: admins
+        sourceFields: [created_by_admin_id]
+        targetFields: [user_id]
+        onDelete: null
+      -
+        type: belongsTo
+        targetCollection: admins
+        sourceFields: [approved_by_admin_id]
+        targetFields: [user_id]
+        onDelete: null
+  stations:
+    tableName: stations
+    collectionName: stations
+    note: null
+    fields:
+      -
+        name: station_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: true
+        default: null
+        note: null
+        enumName: null
+      -
+        name: name
+        dbmlType: "VARCHAR(150)"
+        tsType: string
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: address
+        dbmlType: "VARCHAR(500)"
+        tsType: string
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: latitude
+        dbmlType: DOUBLEPRECISION
+        tsType: number
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: longitude
+        dbmlType: DOUBLEPRECISION
+        tsType: number
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+    indexes: []
+    relations:
+      -
+        type: hasMany
+        targetCollection: staff_at_stations
+        sourceFields: [station_id]
+        targetFields: [station_id]
+        onDelete: cascade
+      -
+        type: hasMany
+        targetCollection: vehicle_at_stations
+        sourceFields: [station_id]
+        targetFields: [station_id]
+        onDelete: cascade
+      -
+        type: hasMany
+        targetCollection: vehicle_transfers
+        sourceFields: [station_id]
+        targetFields: [from_station_id]
+        onDelete: null
+      -
+        type: hasMany
+        targetCollection: vehicle_transfers
+        sourceFields: [station_id]
+        targetFields: [to_station_id]
+        onDelete: null
+      -
+        type: hasMany
+        targetCollection: staff_transfers
+        sourceFields: [station_id]
+        targetFields: [from_station_id]
+        onDelete: null
+      -
+        type: hasMany
+        targetCollection: staff_transfers
+        sourceFields: [station_id]
+        targetFields: [to_station_id]
+        onDelete: null
+  users:
+    tableName: users
+    collectionName: users
+    note: null
+    fields:
+      -
+        name: user_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: true
+        default: null
+        note: null
+        enumName: null
+      -
+        name: role
+        dbmlType: user_role
+        tsType: "enum:user_role"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: unknown
+        note: null
+        enumName: user_role
+      -
+        name: email
+        dbmlType: "VARCHAR(255)"
+        tsType: string
+        required: true
+        unique: true
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: password_hash
+        dbmlType: "VARCHAR(255)"
+        tsType: string
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: full_name
+        dbmlType: "VARCHAR(200)"
+        tsType: string
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: phone
+        dbmlType: "VARCHAR(50)"
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: created_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+    indexes: []
+    relations:
+      -
+        type: hasMany
+        targetCollection: renters
+        sourceFields: [user_id]
+        targetFields: [user_id]
+        onDelete: cascade
+      -
+        type: hasMany
+        targetCollection: staff
+        sourceFields: [user_id]
+        targetFields: [user_id]
+        onDelete: cascade
+      -
+        type: hasMany
+        targetCollection: admins
+        sourceFields: [user_id]
+        targetFields: [user_id]
+        onDelete: cascade
+  vehicle_at_stations:
+    tableName: vehicle_at_stations
+    collectionName: vehicle_at_stations
+    note: null
+    fields:
+      -
+        name: vehicle_at_station_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: true
+        default: null
+        note: null
+        enumName: null
+      -
+        name: vehicle_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: station_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: start_time
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+      -
+        name: end_time
+        dbmlType: timestamptz
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: current_battery_capacity_kwh
+        dbmlType: DOUBLEPRECISION
+        tsType: number
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: current_mileage
+        dbmlType: integer
+        tsType: number
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: status
+        dbmlType: vehicle_at_stations_status_t
+        tsType: "enum:vehicle_at_stations_status_t"
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: vehicle_at_stations_status_t
+    indexes:
+      -
+        name: ux_vehicle_at_stations_vehicle_start
+        type: null
+        unique: true
+        primaryKey: false
+        note: null
+        columns: [vehicle_id, start_time]
+      -
+        name: ix_vehicle_at_stations_vehicle_end
+        type: null
+        unique: false
+        primaryKey: false
+        note: null
+        columns: [vehicle_id, end_time]
+      -
+        name: ix_vehicle_at_stations_station_end
+        type: null
+        unique: false
+        primaryKey: false
+        note: null
+        columns: [station_id, end_time]
+    relations:
+      -
+        type: belongsTo
+        targetCollection: vehicles
+        sourceFields: [vehicle_id]
+        targetFields: [vehicle_id]
+        onDelete: cascade
+      -
+        type: belongsTo
+        targetCollection: stations
+        sourceFields: [station_id]
+        targetFields: [station_id]
+        onDelete: cascade
+      -
+        type: hasMany
+        targetCollection: bookings
+        sourceFields: [vehicle_at_station_id]
+        targetFields: [vehicle_at_station_id]
+        onDelete: null
+  vehicle_transfers:
+    tableName: vehicle_transfers
+    collectionName: vehicle_transfers
+    note: null
+    fields:
+      -
+        name: vehicle_transfer_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: true
+        default: null
+        note: null
+        enumName: null
+      -
+        name: vehicle_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: from_station_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: to_station_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: picked_up_by_staff_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: picked_up_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: dropped_off_by_staff_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: dropped_off_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: pickup_notes
+        dbmlType: "VARCHAR(1000)"
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: dropoff_notes
+        dbmlType: "VARCHAR(1000)"
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: approved_by_admin_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: created_by_admin_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: created_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: Date.now
+        note: null
+        enumName: null
+      -
+        name: approved_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: scheduled_pickup_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: scheduled_dropoff_at
+        dbmlType: timestamptz
+        tsType: Date
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: status
+        dbmlType: transfer_status
+        tsType: "enum:transfer_status"
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: draft
+        note: null
+        enumName: transfer_status
+      -
+        name: notes
+        dbmlType: "VARCHAR(1000)"
+        tsType: string
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+    indexes:
+      -
+        name: ix_vehicle_transfers_status
+        type: null
+        unique: false
+        primaryKey: false
+        note: null
+        columns: [status]
+      -
+        name: ix_vehicle_transfers_from_to
+        type: null
+        unique: false
+        primaryKey: false
+        note: null
+        columns: [from_station_id, to_station_id]
+    relations:
+      -
+        type: belongsTo
+        targetCollection: stations
+        sourceFields: [from_station_id]
+        targetFields: [station_id]
+        onDelete: null
+      -
+        type: belongsTo
+        targetCollection: stations
+        sourceFields: [to_station_id]
+        targetFields: [station_id]
+        onDelete: null
+      -
+        type: belongsTo
+        targetCollection: admins
+        sourceFields: [created_by_admin_id]
+        targetFields: [user_id]
+        onDelete: null
+      -
+        type: belongsTo
+        targetCollection: admins
+        sourceFields: [approved_by_admin_id]
+        targetFields: [user_id]
+        onDelete: null
+      -
+        type: belongsTo
+        targetCollection: vehicles
+        sourceFields: [vehicle_id]
+        targetFields: [vehicle_id]
+        onDelete: null
+  vehicles:
+    tableName: vehicles
+    collectionName: vehicles
+    note: null
+    fields:
+      -
+        name: vehicle_id
+        dbmlType: INT
+        tsType: Types.ObjectId
+        required: true
+        unique: true
+        primaryKey: true
+        autoIncrement: true
+        default: null
+        note: null
+        enumName: null
+      -
+        name: make
+        dbmlType: "VARCHAR(100)"
+        tsType: string
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: model
+        dbmlType: "VARCHAR(100)"
+        tsType: string
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: model_year
+        dbmlType: INT
+        tsType: number
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: category
+        dbmlType: "VARCHAR(50)"
+        tsType: string
+        required: true
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: EV
+        note: null
+        enumName: null
+      -
+        name: battery_capacity_kwh
+        dbmlType: DOUBLEPRECISION
+        tsType: number
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: range_km
+        dbmlType: DOUBLEPRECISION
+        tsType: number
+        required: false
+        unique: false
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: null
+        enumName: null
+      -
+        name: vin_number
+        dbmlType: "varchar(50)"
+        tsType: string
+        required: false
+        unique: true
+        primaryKey: false
+        autoIncrement: false
+        default: null
+        note: "Vehicle Identification Number"
+        enumName: null
+    indexes: []
+    relations:
+      -
+        type: hasMany
+        targetCollection: vehicle_at_stations
+        sourceFields: [vehicle_id]
+        targetFields: [vehicle_id]
+        onDelete: cascade
+      -
+        type: hasMany
+        targetCollection: rentals
+        sourceFields: [vehicle_id]
+        targetFields: [vehicle_id]
+        onDelete: null
+      -
+        type: hasMany
+        targetCollection: pricings
+        sourceFields: [vehicle_id]
+        targetFields: [vehicle_id]
+        onDelete: cascade
+      -
+        type: hasMany
+        targetCollection: vehicle_transfers
+        sourceFields: [vehicle_id]
+        targetFields: [vehicle_id]
+        onDelete: null

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "sync-indexes": "ts-node --project tsconfig.json tools/sync-indexes.ts",
+    "dbml:generate-spec": "ts-node --project tsconfig.json tools/dbml-to-spec.ts"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"

--- a/tools/dbml-to-spec.ts
+++ b/tools/dbml-to-spec.ts
@@ -1,0 +1,360 @@
+#!/usr/bin/env ts-node
+import { Parser } from '@dbml/core';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+type Primitive = string | number | boolean | null;
+type JsonValue = Primitive | JsonValue[] | { [key: string]: JsonValue };
+
+type FieldLike = {
+  name: string;
+  type?: { type_name?: string | null } | null;
+  not_null?: boolean;
+  unique?: boolean;
+  pk?: boolean;
+  dbdefault?: { type?: string | null; value?: unknown } | null;
+  note?: string | null;
+  increment?: boolean;
+  _enum?: { name: string } | null;
+};
+
+type TableLike = {
+  name: string;
+  note?: string | null;
+  fields: FieldLike[];
+  indexes: Array<{
+    name?: string | null;
+    unique?: boolean;
+    pk?: boolean;
+    type?: string | null;
+    note?: string | null;
+    columns: Array<{ value: string; type?: string | null }>;
+  }>;
+};
+
+type EndpointLike = {
+  tableName: string;
+  relation: string;
+  fieldNames: string[];
+};
+
+type RefLike = {
+  endpoints: [EndpointLike, EndpointLike];
+  onDelete?: string | null;
+};
+
+type SchemaLike = {
+  tables: TableLike[];
+  enums: Array<{ name: string; values: Array<{ name: string }> }>;
+  refs: RefLike[];
+};
+
+const SCALAR_SAFE_PATTERN = /^[A-Za-z0-9_\-.]+$/;
+
+function isPrimitive(value: JsonValue): value is Primitive {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  );
+}
+
+function formatScalar(value: Primitive): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (value.length === 0) {
+    return "''";
+  }
+  if (SCALAR_SAFE_PATTERN.test(value)) {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+function toYaml(value: JsonValue, indent = 0): string {
+  const pad = '  '.repeat(indent);
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return `${pad}[]`;
+    }
+    return value
+      .map((entry) => {
+        if (isPrimitive(entry)) {
+          return `${pad}- ${formatScalar(entry)}`;
+        }
+        const child = toYaml(entry, indent + 1);
+        return `${pad}-\n${child}`;
+      })
+      .join('\n');
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value);
+    if (entries.length === 0) {
+      return `${pad}{}`;
+    }
+    return entries
+      .map(([key, entry]) => {
+        const keyLine = `${pad}${key}:`;
+        if (entry === undefined) {
+          return `${keyLine} null`;
+        }
+        if (isPrimitive(entry)) {
+          return `${keyLine} ${formatScalar(entry)}`;
+        }
+        if (Array.isArray(entry)) {
+          if (entry.length === 0) {
+            return `${keyLine} []`;
+          }
+          if (entry.every(isPrimitive)) {
+            const serialized = entry.map((item) => formatScalar(item)).join(', ');
+            return `${keyLine} [${serialized}]`;
+          }
+          const child = toYaml(entry, indent + 1);
+          return `${keyLine}\n${child}`;
+        }
+        const childEntries = Object.entries(entry);
+        if (childEntries.length === 0) {
+          return `${keyLine} {}`;
+        }
+        const child = toYaml(entry, indent + 1);
+        return `${keyLine}\n${child}`;
+      })
+      .join('\n');
+  }
+  return `${pad}${formatScalar(value)}`;
+}
+
+function normalizeDbmlType(field: FieldLike): string {
+  return field.type?.type_name ?? 'unknown';
+}
+
+function mapDefaultValue(field: FieldLike): Primitive {
+  const defaultInfo = field.dbdefault;
+  if (!defaultInfo || defaultInfo.value === undefined || defaultInfo.value === null) {
+    return null;
+  }
+
+  const { type, value } = defaultInfo;
+  if (type === 'number' && typeof value === 'number') {
+    return value;
+  }
+  if (type === 'boolean') {
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    if (typeof value === 'string') {
+      return value.toLowerCase() === 'true';
+    }
+  }
+  if (type === 'string' && typeof value === 'string') {
+    return value;
+  }
+  if (type === 'expression' && typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'now()' || normalized === 'current_timestamp') {
+      return 'Date.now';
+    }
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'string') {
+    return value;
+  }
+  return JSON.stringify(value) ?? null;
+}
+
+function mapTsType(field: FieldLike): string {
+  if (field._enum?.name) {
+    return `enum:${field._enum.name}`;
+  }
+  const raw = normalizeDbmlType(field).toLowerCase();
+  if (!raw || raw === 'unknown') {
+    return 'unknown';
+  }
+  if (raw.includes('int')) {
+    if (field.name.endsWith('_id')) {
+      return 'Types.ObjectId';
+    }
+    return 'number';
+  }
+  if (raw.includes('numeric') || raw.includes('decimal')) {
+    return 'Decimal128';
+  }
+  if (raw.includes('double') || raw.includes('float')) {
+    return 'number';
+  }
+  if (raw.includes('char') || raw.includes('text') || raw.includes('inet')) {
+    return 'string';
+  }
+  if (
+    raw.includes('time') ||
+    raw.includes('date') ||
+    raw.includes('timestamp') ||
+    raw === 'timestamptz'
+  ) {
+    return 'Date';
+  }
+  if (raw === 'boolean') {
+    return 'boolean';
+  }
+  if (raw === 'uuid' || raw === 'uniqueidentifier') {
+    return 'Types.ObjectId';
+  }
+  return 'string';
+}
+
+function makeFieldSpec(field: FieldLike) {
+  return {
+    name: field.name,
+    dbmlType: normalizeDbmlType(field),
+    tsType: mapTsType(field),
+    required: Boolean(field.not_null || field.pk),
+    unique: Boolean(field.unique || field.pk),
+    primaryKey: Boolean(field.pk),
+    autoIncrement: Boolean(field.increment),
+    default: mapDefaultValue(field),
+    note: field.note ?? null,
+    enumName: field._enum?.name ?? null,
+  };
+}
+
+function makeIndexSpec(index: TableLike['indexes'][number]) {
+  return {
+    name: index.name ?? null,
+    type: index.type ?? null,
+    unique: Boolean(index.unique || index.pk),
+    primaryKey: Boolean(index.pk),
+    note: index.note ?? null,
+    columns: index.columns.map((column) => column.value),
+  };
+}
+
+function relationTypeForEndpoint(relation: string, otherRelation: string): 'hasMany' | 'belongsTo' | 'hasOne' | 'manyToMany' {
+  if (relation === '*' && otherRelation === '*') {
+    return 'manyToMany';
+  }
+  if (relation === '*' && otherRelation === '1') {
+    return 'belongsTo';
+  }
+  if (relation === '1' && otherRelation === '*') {
+    return 'hasMany';
+  }
+  return 'hasOne';
+}
+
+function buildRelations(schema: SchemaLike) {
+  const relationMap = new Map<string, Array<{
+    type: string;
+    targetCollection: string;
+    sourceFields: string[];
+    targetFields: string[];
+    onDelete: string | null;
+  }>>();
+
+  const ensure = (key: string) => {
+    if (!relationMap.has(key)) {
+      relationMap.set(key, []);
+    }
+    return relationMap.get(key)!;
+  };
+
+  for (const ref of schema.refs) {
+    const [left, right] = ref.endpoints;
+    const leftType = relationTypeForEndpoint(left.relation, right.relation);
+    const rightType = relationTypeForEndpoint(right.relation, left.relation);
+    const onDelete = ref.onDelete ?? null;
+
+    ensure(left.tableName).push({
+      type: leftType,
+      targetCollection: right.tableName,
+      sourceFields: left.fieldNames ?? [],
+      targetFields: right.fieldNames ?? [],
+      onDelete,
+    });
+
+    ensure(right.tableName).push({
+      type: rightType,
+      targetCollection: left.tableName,
+      sourceFields: right.fieldNames ?? [],
+      targetFields: left.fieldNames ?? [],
+      onDelete,
+    });
+  }
+
+  return relationMap;
+}
+
+async function main() {
+  const dbmlPathArg = process.argv[2] ?? process.env.DBML_PATH ?? 'DB.dbml';
+  const dbmlPath = path.resolve(process.cwd(), dbmlPathArg);
+  const parser = new Parser();
+  const content = await readFile(dbmlPath, 'utf8');
+  const database = parser.parse(content, 'dbml');
+  const rawSchema = database.schemas?.[0];
+
+  if (!rawSchema) {
+    throw new Error('No schema found in DBML file.');
+  }
+
+  const schema = rawSchema as unknown as SchemaLike;
+
+  const relations = buildRelations(schema);
+
+  const collections = schema.tables
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((table) => {
+      const fields = table.fields.map(makeFieldSpec);
+      const indexes = table.indexes?.map(makeIndexSpec) ?? [];
+      const relationsForTable = relations.get(table.name) ?? [];
+      return [
+        table.name,
+        {
+          tableName: table.name,
+          collectionName: table.name,
+          note: table.note ?? null,
+          fields,
+          indexes,
+          relations: relationsForTable,
+        },
+      ] as const;
+    });
+
+  const enums = schema.enums
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((enumDef) => [
+      enumDef.name,
+      {
+        name: enumDef.name,
+        values: enumDef.values.map((value) => value.name),
+      },
+    ] as const);
+
+  const spec: JsonValue = {
+    source: path.relative(process.cwd(), dbmlPath),
+    generatedAt: new Date().toISOString(),
+    fixes: [],
+    enums: Object.fromEntries(enums),
+    collections: Object.fromEntries(collections),
+  };
+
+  const docsDir = path.resolve(process.cwd(), 'docs');
+  await mkdir(docsDir, { recursive: true });
+
+  const jsonPath = path.join(docsDir, 'model-spec.json');
+  const yamlPath = path.join(docsDir, 'model-spec.yml');
+
+  await writeFile(jsonPath, `${JSON.stringify(spec, null, 2)}\n`);
+  await writeFile(yamlPath, `${toYaml(spec)}\n`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tools/sync-indexes.ts
+++ b/tools/sync-indexes.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env ts-node
+import { stdout } from 'node:process';
+
+stdout.write(
+  'sync-indexes script placeholder. Implement index synchronization logic in later steps.\n',
+);


### PR DESCRIPTION
## Summary
- add a placeholder `sync-indexes` script entry so the command is available for future work
- introduce a `tools/dbml-to-spec.ts` helper that parses the DBML and emits JSON/YAML specs
- generate `docs/model-spec.(json|yml)` from the DBML to use as the model source of truth

## Testing
- `pnpm run dbml:generate-spec`


------
https://chatgpt.com/codex/tasks/task_e_68e8062670b08320b0d49c4bc0e7d4c7