### PR TITLE
Add model diff generator and documentation

### DIFF
--- a/docs/model-diff.md
+++ b/docs/model-diff.md
@@ -1,0 +1,242 @@
+# Model Diff
+
+- Generated at: 2025-10-09T19:33:16.004Z
+- DBML spec: docs/model-spec.json
+- Code map: docs/current-model-map.json
+
+## Enum Overview
+- Missing enums: booking_status, booking_verification_status, confirmation_type, contract_status, esign_provider, fee_type, inspection_type, kyc_status, kyc_type, party_role, payment_method, payment_status, rental_status, signature_event_type, signature_type, transfer_status, user_role, vehicle_at_stations_status_t
+- Extra enums: ContractProvider, ContractStatus, FeeType, InspectorType, KycsStatus, KycsType, PaymentMethod, PaymentStatus, RetalStatus, Role, SignatureEvent, SignatureType, StaffTransferStatus, StatusBooking, StatusVehicleAtStation, VehicleTransferStatus, VerificationStatus
+
+## Collections Overview
+- Missing collections: reports_photo, staff
+- Extra collections: reports_photos, staffs
+
+### admins
+- Field `user_id`: type spec=Types.ObjectId current=User; unique spec=true current=false
+- Field `title`: required spec=false current=true
+- Field `notes`: required spec=false current=true
+- Field `hire_date`: default spec=Date.now current=null
+- Indexes: ✅ Matches spec
+- Missing relations: user_id->users | user_id->vehicle_transfers | user_id->staff_transfers
+- Extra relations: user_id->user
+
+### bookings
+- Missing fields: booking_id, booking_created_at
+- Extra fields: booking_create_at
+- Field `renter_id`: type spec=Types.ObjectId current=Renter
+- Field `vehicle_at_station_id`: type spec=Types.ObjectId current=VehicleAtStation
+- Field `expected_return_datetime`: required spec=false current=true
+- Field `status`: type spec=enum:booking_status current=StatusBooking; default spec=pending_verification current=StatusBooking.PENDING_VERIFICATION
+- Field `verification_status`: type spec=enum:booking_verification_status current=VerificationStatus; default spec=pending current=VerificationStatus.PENDING
+- Field `verified_by_staff_id`: type spec=Types.ObjectId current=Staff; required spec=false current=true
+- Missing indexes: renter_id | vehicle_at_station_id
+- Missing relations: renter_id->renters | vehicle_at_station_id->vehicle_at_stations | verified_by_staff_id->staff | booking_id->fees | booking_id->rentals
+- Extra relations: renter_id->renter | vehicle_at_station_id->vehicleatstation | verified_by_staff_id->user
+
+### contracts
+- Missing fields: contract_id, updated_at
+- Field `rental_id`: type spec=Types.ObjectId current=Rental
+- Field `status`: type spec=enum:contract_status current=ContractStatus; default spec=issued current=null
+- Field `issued_at`: default spec=Date.now current=null
+- Field `completed_at`: required spec=false current=true
+- Field `provider`: type spec=enum:esign_provider current=ContractProvider; default spec=native current=null
+- Field `provider_envelope_id`: required spec=false current=true
+- Field `audit_trail_url`: required spec=false current=true
+- Indexes: ✅ Matches spec
+- Missing relations: rental_id->rentals | contract_id->signatures
+- Extra relations: rental_id->rental
+
+### fees
+- Missing fields: fee_id, created_at
+- Field `booking_id`: type spec=Types.ObjectId current=Booking
+- Field `type`: type spec=enum:fee_type current=FeeType; default spec=deposit current=null
+- Field `amount`: type spec=Decimal128 current=number
+- Field `currency`: default spec=USD current=null
+- Missing indexes: booking_id
+- Missing relations: booking_id->bookings | fee_id->payments
+- Extra relations: booking_id->booking
+
+### inspections
+- Missing fields: inspection_id, inspected_at
+- Extra fields: inspection_at
+- Field `rental_id`: type spec=Types.ObjectId current=Rental
+- Field `type`: type spec=enum:inspection_type current=InspectorType; default spec=pre_rental current=null
+- Field `inspector_staff_id`: type spec=Types.ObjectId current=Staff; required spec=false current=true
+- Field `current_battery_capacity_kwh`: required spec=false current=true
+- Missing indexes: rental_id, type
+- Missing relations: rental_id->rentals | inspection_id->reports
+- Extra relations: rental_id->rental
+- Relation [inspector_staff_id->staff]: type spec=belongsTo current=referencesOne; onDelete=set null
+
+### kycs
+- Missing fields: kyc_id, document_number, expiry_date
+- Field `renter_id`: type spec=Types.ObjectId current=Renter
+- Field `type`: type spec=enum:kyc_type current=KycsType; default spec=driver_license current=KycsType.DRIVER_LICENSE
+- Field `status`: type spec=enum:kyc_status current=KycsStatus; default spec=submitted current=KycsStatus.SUBMITTED
+- Missing indexes: renter_id
+- Missing relations: renter_id->renters
+- Extra relations: renter_id->renter
+
+### payments
+- Missing fields: payment_id
+- Field `method`: type spec=enum:payment_method current=PaymentMethod; default spec=unknown current=null
+- Field `status`: type spec=enum:payment_status current=PaymentStatus; default spec=paid current=null
+- Field `amount_paid`: type spec=Decimal128 current=number
+- Field `paid_at`: default spec=Date.now current=null
+- Field `provider_reference`: required spec=false current=true
+- Indexes: ✅ Matches spec
+- Missing relations: payment_id->fees
+
+### pricings
+- Missing fields: pricing_id
+- Field `vehicle_id`: type spec=Types.ObjectId current=Vehicle
+- Field `price_per_hour`: type spec=Decimal128 current=number
+- Field `price_per_day`: type spec=Decimal128 current=number; required spec=false current=true
+- Field `effective_from`: required spec=true current=false
+- Field `deposit_amount`: type spec=Decimal128 current=number
+- Field `late_return_fee_per_hour`: type spec=Decimal128 current=number
+- Field `excess_mileage_fee`: type spec=Decimal128 current=number
+- Missing indexes: effective_from, vehicle_id
+- Missing relations: vehicle_id->vehicles
+- Extra relations: vehicle_id->vehicle
+
+### rentals
+- Missing fields: rental_id, pickup_datetime
+- Extra fields: pickup_date
+- Field `booking_id`: type spec=Types.ObjectId current=Booking; unique spec=true current=false
+- Field `vehicle_id`: type spec=Types.ObjectId current=Vehicle
+- Field `expected_return_datetime`: required spec=false current=true
+- Field `status`: type spec=enum:rental_status current=RetalStatus; default spec=reserved current=null
+- Field `score`: required spec=true current=false; default spec=null current=0
+- Missing indexes: vehicle_id
+- Missing relations: booking_id->bookings | vehicle_id->vehicles | rental_id->contracts | rental_id->inspections
+- Extra relations: booking_id->booking | vehicle_id->vehicle
+
+### renters
+- Missing fields: driver_license_no
+- Extra fields: driver_license
+- Field `user_id`: type spec=Types.ObjectId current=User; unique spec=true current=false
+- Field `date_of_birth`: required spec=false current=true
+- Field `address`: required spec=false current=true
+- Field `risk_score`: required spec=false current=true
+- Indexes: ✅ Matches spec
+- Missing relations: user_id->users | user_id->bookings | user_id->kycs
+- Extra relations: user_id->user
+
+### reports
+- Missing fields: report_id, inspection_id
+- Extra fields: inspector_id
+- Field `notes`: required spec=false current=true
+- Field `damage_found`: default spec=false current=null
+- Missing indexes: inspection_id
+- Missing relations: report_id->reports_photo | inspection_id->inspections
+- Extra relations: inspector_id->inspection
+
+### reports_photo
+- Status: ❌ Missing from codebase
+
+### reports_photos
+- Status: ⚠️ Only present in codebase (not defined in DBML)
+
+### signatures
+- Missing fields: signature_id, signer_ip
+- Extra fields: signer_ip_address
+- Field `contract_id`: type spec=Types.ObjectId current=string
+- Field `role`: type spec=enum:party_role current=Role
+- Field `signature_event`: type spec=enum:signature_event_type current=SignatureEvent; required spec=false current=true
+- Field `type`: type spec=enum:signature_type current=SignatureType; default spec=digital_cert current=null
+- Field `signed_at`: default spec=Date.now current=null
+- Field `user_agent`: required spec=false current=true
+- Field `provider_signature_id`: required spec=false current=true
+- Field `signature_image_url`: required spec=false current=true
+- Field `cert_subject`: required spec=false current=true
+- Field `cert_issuer`: required spec=false current=true
+- Field `cert_serial`: required spec=false current=true
+- Field `cert_fingerprint_sha256`: required spec=false current=true
+- Field `signature_hash`: required spec=false current=true
+- Field `evidence_url`: required spec=false current=true
+- Missing indexes: contract_id
+- Missing relations: contract_id->contracts
+- Extra relations: contract_id->contract
+
+### staff
+- Status: ❌ Missing from codebase
+
+### staff_at_stations
+- Field `staff_id`: type spec=Types.ObjectId current=Staff
+- Field `start_time`: default spec=Date.now current=null
+- Field `station_id`: type spec=Types.ObjectId current=Station
+- Field `role_at_station`: required spec=false current=true
+- Missing indexes: staff_id, start_time | end_time, staff_id | end_time, station_id
+- Missing relations: station_id->stations
+- Extra relations: station_id->station
+- Relation [staff_id->staff]: type spec=belongsTo current=referencesOne; onDelete=cascade
+
+### staff_transfers
+- Missing fields: staff_transfer_id
+- Field `staff_id`: type spec=Types.ObjectId current=Staff
+- Field `from_station_id`: type spec=Types.ObjectId current=Station
+- Field `to_station_id`: type spec=Types.ObjectId current=Station
+- Field `approved_by_admin_id`: type spec=Types.ObjectId current=Admin
+- Field `created_by_admin_id`: type spec=Types.ObjectId current=Admin
+- Field `status`: type spec=enum:transfer_status current=StaffTransferStatus; default spec=draft current=StaffTransferStatus.DRAFT
+- Missing indexes: staff_id, status | to_station_id
+- Missing relations: from_station_id->stations | to_station_id->stations | created_by_admin_id->admins | approved_by_admin_id->admins
+- Extra relations: from_station_id->station | to_station_id->station | approved_by_admin_id->admin | created_by_admin_id->admin
+- Relation [staff_id->staff]: type spec=belongsTo current=referencesOne
+
+### staffs
+- Status: ⚠️ Only present in codebase (not defined in DBML)
+
+### stations
+- Missing fields: station_id
+- Field `latitude`: type spec=number current=string; required spec=false current=true
+- Field `longitude`: type spec=number current=string; required spec=false current=true
+- Indexes: ✅ Matches spec
+- Missing relations: station_id->staff_at_stations | station_id->vehicle_at_stations | station_id->vehicle_transfers | station_id->staff_transfers
+
+### users
+- Missing fields: user_id, created_at
+- Extra fields: is_active
+- Field `role`: type spec=enum:user_role current=string; default spec=unknown current=null
+- Field `email`: unique spec=true current=false
+- Indexes: ✅ Matches spec
+- Missing relations: user_id->renters | user_id->staff | user_id->admins
+
+### vehicle_at_stations
+- Missing fields: vehicle_at_station_id
+- Field `vehicle_id`: type spec=Types.ObjectId current=Vehicle
+- Field `station_id`: type spec=Types.ObjectId current=Station
+- Field `start_time`: default spec=Date.now current=null
+- Field `end_time`: required spec=false current=true
+- Field `current_battery_capacity_kwh`: required spec=false current=true
+- Field `status`: type spec=enum:vehicle_at_stations_status_t current=StatusVehicleAtStation; required spec=false current=true
+- Missing indexes: start_time, vehicle_id | end_time, vehicle_id | end_time, station_id
+- Missing relations: vehicle_id->vehicles | station_id->stations | vehicle_at_station_id->bookings
+- Extra relations: vehicle_id->vehicle | station_id->station
+
+### vehicle_transfers
+- Missing fields: vehicle_transfer_id
+- Field `vehicle_id`: type spec=Types.ObjectId current=Vehicle
+- Field `from_station_id`: type spec=Types.ObjectId current=Station
+- Field `to_station_id`: type spec=Types.ObjectId current=Station
+- Field `picked_up_by_staff_id`: type spec=Types.ObjectId current=number
+- Field `dropped_off_by_staff_id`: type spec=Types.ObjectId current=number
+- Field `approved_by_admin_id`: type spec=Types.ObjectId current=string
+- Field `created_by_admin_id`: type spec=Types.ObjectId current=string
+- Field `scheduled_pickup_at`: required spec=false current=true
+- Field `scheduled_dropoff_at`: required spec=false current=true
+- Field `status`: type spec=enum:transfer_status current=VehicleTransferStatus; default spec=draft current=VehicleTransferStatus.DRAFT
+- Missing indexes: status | from_station_id, to_station_id
+- Missing relations: from_station_id->stations | to_station_id->stations | created_by_admin_id->admins | approved_by_admin_id->admins | vehicle_id->vehicles
+- Extra relations: vehicle_id->vehicle | from_station_id->station | to_station_id->station
+
+### vehicles
+- Missing fields: vehicle_id
+- Field `category`: default spec=EV current=null
+- Field `battery_capacity_kwh`: required spec=false current=true
+- Field `range_km`: required spec=false current=true
+- Field `vin_number`: required spec=false current=true
+- Indexes: ✅ Matches spec
+- Missing relations: vehicle_id->vehicle_at_stations | vehicle_id->rentals | vehicle_id->pricings | vehicle_id->vehicle_transfers

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "sync-indexes": "ts-node --project tsconfig.json tools/sync-indexes.ts",
     "dbml:generate-spec": "ts-node --project tsconfig.json tools/dbml-to-spec.ts",
-    "code:current-model-map": "ts-node --project tsconfig.json tools/current-model-map.ts"
+    "code:current-model-map": "ts-node --project tsconfig.json tools/current-model-map.ts",
+    "docs:model-diff": "ts-node --project tsconfig.json tools/model-diff.ts"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"

--- a/tools/model-diff.ts
+++ b/tools/model-diff.ts
@@ -1,0 +1,422 @@
+import fs from 'fs';
+import path from 'path';
+
+type SpecField = {
+  name: string;
+  dbmlType?: string | null;
+  tsType?: string | null;
+  required?: boolean;
+  unique?: boolean;
+  default?: unknown;
+  note?: string | null;
+  enumName?: string | null;
+};
+
+type SpecIndex = {
+  name?: string | null;
+  type?: string | null;
+  unique?: boolean;
+  primaryKey?: boolean;
+  note?: string | null;
+  columns: string[];
+};
+
+type SpecRelation = {
+  type: string;
+  targetCollection: string | null;
+  sourceFields: string[];
+  targetFields: string[];
+  onDelete?: string | null;
+};
+
+type SpecCollection = {
+  name: string;
+  collectionName?: string | null;
+  fields: SpecField[];
+  indexes: SpecIndex[];
+  relations: SpecRelation[];
+};
+
+type SpecEnum = {
+  name: string;
+  values: string[];
+};
+
+type ModelSpec = {
+  source: string;
+  generatedAt: string;
+  fixes?: unknown[];
+  enums: Record<string, SpecEnum>;
+  collections: Record<string, SpecCollection>;
+};
+
+type CurrentField = {
+  name: string;
+  tsType: string | null;
+  mongooseType: unknown;
+  required: boolean;
+  unique: boolean;
+  default: unknown;
+  ref: string | null;
+  enum: unknown;
+  isArray: boolean;
+};
+
+type CurrentIndex = {
+  columns: string[];
+  options: Record<string, unknown> | null;
+  rawExpression: string;
+};
+
+type CurrentRelation = {
+  type: string;
+  targetCollection: string | null;
+  sourceFields: string[];
+  targetFields: string[];
+};
+
+type CurrentCollection = {
+  name: string;
+  collectionName: string | null;
+  fields: CurrentField[];
+  indexes: CurrentIndex[];
+  relations: CurrentRelation[];
+};
+
+type CurrentEnum = {
+  name: string;
+  values: string[];
+};
+
+type CurrentModelMap = {
+  source: string;
+  generatedAt: string;
+  enums: Record<string, CurrentEnum>;
+  collections: Record<string, CurrentCollection>;
+};
+
+const projectRoot = path.resolve(__dirname, '..');
+const docsDir = path.join(projectRoot, 'docs');
+const specPath = path.join(docsDir, 'model-spec.json');
+const currentPath = path.join(docsDir, 'current-model-map.json');
+const diffPath = path.join(docsDir, 'model-diff.md');
+
+function readJson<T>(filePath: string): T {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Missing required file: ${filePath}`);
+  }
+  const content = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(content) as T;
+}
+
+function stringifyValue(value: unknown): string {
+  if (value === undefined) {
+    return 'undefined';
+  }
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+function normalizeColumns(columns: string[]): string {
+  return columns.map((column) => column.trim()).sort().join(', ');
+}
+
+function normalizeRelationKey(sourceFields: string[], targetCollection: string | null): string {
+  const sourceKey = sourceFields.slice().sort().join(',');
+  const targetKey = targetCollection ? targetCollection.toLowerCase() : 'null';
+  return `${sourceKey}->${targetKey}`;
+}
+
+function buildFieldMap<T extends { name: string }>(fields: T[]): Map<string, T> {
+  const map = new Map<string, T>();
+  fields.forEach((field) => {
+    map.set(field.name, field);
+  });
+  return map;
+}
+
+function compareFields(specFields: SpecField[], currentFields: CurrentField[]): string[] {
+  const messages: string[] = [];
+  const specFieldMap = buildFieldMap(specFields);
+  const currentFieldMap = buildFieldMap(currentFields);
+
+  const missingFields = Array.from(specFieldMap.keys()).filter((name) => !currentFieldMap.has(name));
+  const extraFields = Array.from(currentFieldMap.keys()).filter((name) => !specFieldMap.has(name));
+
+  if (missingFields.length) {
+    messages.push(`- Missing fields: ${missingFields.join(', ')}`);
+  }
+  if (extraFields.length) {
+    messages.push(`- Extra fields: ${extraFields.join(', ')}`);
+  }
+
+  const sharedNames = Array.from(specFieldMap.keys()).filter((name) => currentFieldMap.has(name));
+  sharedNames.forEach((name) => {
+    const specField = specFieldMap.get(name)!;
+    const currentField = currentFieldMap.get(name)!;
+    const fieldMessages: string[] = [];
+
+    const currentType = currentField.tsType || stringifyValue(currentField.mongooseType);
+    if (specField.tsType && specField.tsType !== currentType) {
+      fieldMessages.push(`type spec=${specField.tsType} current=${currentType}`);
+    }
+    if (specField.required !== undefined && specField.required !== currentField.required) {
+      fieldMessages.push(`required spec=${specField.required} current=${currentField.required}`);
+    }
+    if (specField.unique !== undefined && specField.unique !== currentField.unique) {
+      fieldMessages.push(`unique spec=${specField.unique} current=${currentField.unique}`);
+    }
+    const specDefault = stringifyValue(specField.default);
+    const currentDefault = stringifyValue(currentField.default);
+    if (specDefault !== 'undefined' && specDefault !== currentDefault) {
+      fieldMessages.push(`default spec=${specDefault} current=${currentDefault}`);
+    }
+    if (specField.enumName) {
+      const enumValues = Array.isArray(currentField.enum) ? currentField.enum.join(', ') : stringifyValue(currentField.enum);
+      if (!enumValues || enumValues === 'undefined') {
+        fieldMessages.push(`enum spec=${specField.enumName} current=missing`);
+      }
+    }
+
+    if (fieldMessages.length) {
+      messages.push(`- Field \`${name}\`: ${fieldMessages.join('; ')}`);
+    }
+  });
+
+  if (!messages.length) {
+    messages.push('- Fields: ✅ Matches spec');
+  }
+
+  return messages;
+}
+
+function compareIndexes(specIndexes: SpecIndex[], currentIndexes: CurrentIndex[]): string[] {
+  const messages: string[] = [];
+  const specMap = new Map<string, SpecIndex>();
+  specIndexes.forEach((index) => {
+    specMap.set(normalizeColumns(index.columns), index);
+  });
+  const currentMap = new Map<string, CurrentIndex>();
+  currentIndexes.forEach((index) => {
+    currentMap.set(normalizeColumns(index.columns), index);
+  });
+
+  const missing = Array.from(specMap.keys()).filter((key) => !currentMap.has(key));
+  const extra = Array.from(currentMap.keys()).filter((key) => !specMap.has(key));
+
+  if (missing.length) {
+    messages.push(`- Missing indexes: ${missing.join(' | ')}`);
+  }
+  if (extra.length) {
+    messages.push(`- Extra indexes: ${extra.join(' | ')}`);
+  }
+
+  const shared = Array.from(specMap.keys()).filter((key) => currentMap.has(key));
+  shared.forEach((key) => {
+    const specIndex = specMap.get(key)!;
+    const currentIndex = currentMap.get(key)!;
+    const specUnique = specIndex.unique ?? false;
+    const currentUnique = Boolean(currentIndex.options?.unique);
+    const diffs: string[] = [];
+    if (specUnique !== currentUnique) {
+      diffs.push(`unique spec=${specUnique} current=${currentUnique}`);
+    }
+    if (specIndex.type && specIndex.type !== (currentIndex.options?.type as string | undefined)) {
+      diffs.push(`type spec=${specIndex.type} current=${currentIndex.options?.type}`);
+    }
+    if (specIndex.primaryKey && !currentUnique) {
+      diffs.push('primary key missing');
+    }
+    if (diffs.length) {
+      messages.push(`- Index [${key}]: ${diffs.join('; ')}`);
+    }
+  });
+
+  if (!messages.length) {
+    messages.push('- Indexes: ✅ Matches spec');
+  }
+
+  return messages;
+}
+
+function compareRelations(specRelations: SpecRelation[], currentRelations: CurrentRelation[]): string[] {
+  const messages: string[] = [];
+  const specMap = new Map<string, SpecRelation>();
+  specRelations.forEach((relation) => {
+    const key = normalizeRelationKey(relation.sourceFields, relation.targetCollection);
+    specMap.set(key, relation);
+  });
+  const currentMap = new Map<string, CurrentRelation>();
+  currentRelations.forEach((relation) => {
+    const key = normalizeRelationKey(relation.sourceFields, relation.targetCollection);
+    currentMap.set(key, relation);
+  });
+
+  const missing = Array.from(specMap.keys()).filter((key) => !currentMap.has(key));
+  const extra = Array.from(currentMap.keys()).filter((key) => !specMap.has(key));
+
+  if (missing.length) {
+    messages.push(`- Missing relations: ${missing.join(' | ')}`);
+  }
+  if (extra.length) {
+    messages.push(`- Extra relations: ${extra.join(' | ')}`);
+  }
+
+  const shared = Array.from(specMap.keys()).filter((key) => currentMap.has(key));
+  shared.forEach((key) => {
+    const specRelation = specMap.get(key)!;
+    const currentRelation = currentMap.get(key)!;
+    const diffs: string[] = [];
+    const specType = specRelation.type;
+    const currentType = currentRelation.type;
+    if (specType && currentType && specType !== currentType) {
+      diffs.push(`type spec=${specType} current=${currentType}`);
+    }
+    const specTarget = specRelation.targetCollection ? specRelation.targetCollection.toLowerCase() : null;
+    const currentTarget = currentRelation.targetCollection ? currentRelation.targetCollection.toLowerCase() : null;
+    if (specTarget !== currentTarget) {
+      diffs.push(`target spec=${specTarget ?? 'null'} current=${currentTarget ?? 'null'}`);
+    }
+    if (specRelation.onDelete && specRelation.onDelete !== 'NO ACTION') {
+      diffs.push(`onDelete=${specRelation.onDelete}`);
+    }
+    if (diffs.length) {
+      messages.push(`- Relation [${key}]: ${diffs.join('; ')}`);
+    }
+  });
+
+  if (!messages.length) {
+    messages.push('- Relations: ✅ Matches spec');
+  }
+
+  return messages;
+}
+
+function compareEnums(specEnums: Record<string, SpecEnum>, currentEnums: Record<string, CurrentEnum>): string[] {
+  const messages: string[] = [];
+  const specNames = Object.keys(specEnums);
+  const currentNames = Object.keys(currentEnums);
+
+  const missing = specNames.filter((name) => !currentEnums[name]);
+  const extra = currentNames.filter((name) => !specEnums[name]);
+
+  if (missing.length) {
+    messages.push(`- Missing enums: ${missing.join(', ')}`);
+  }
+  if (extra.length) {
+    messages.push(`- Extra enums: ${extra.join(', ')}`);
+  }
+
+  const shared = specNames.filter((name) => currentEnums[name]);
+  shared.forEach((name) => {
+    const specValues = new Set(specEnums[name].values);
+    const currentValues = new Set(currentEnums[name].values);
+    const missingValues = Array.from(specValues).filter((value) => !currentValues.has(value));
+    const extraValues = Array.from(currentValues).filter((value) => !specValues.has(value));
+    if (missingValues.length || extraValues.length) {
+      const parts: string[] = [];
+      if (missingValues.length) {
+        parts.push(`missing: ${missingValues.join(', ')}`);
+      }
+      if (extraValues.length) {
+        parts.push(`extra: ${extraValues.join(', ')}`);
+      }
+      messages.push(`- Enum \`${name}\`: ${parts.join('; ')}`);
+    }
+  });
+
+  if (!messages.length) {
+    messages.push('- Enums: ✅ Matches spec');
+  }
+
+  return messages;
+}
+
+function generateCollectionDiff(
+  name: string,
+  specCollection: SpecCollection | undefined,
+  currentCollection: CurrentCollection | undefined,
+): string[] {
+  const lines: string[] = [];
+  lines.push(`### ${name}`);
+
+  if (!specCollection) {
+    lines.push('- Status: ⚠️ Only present in codebase (not defined in DBML)');
+    return lines;
+  }
+  if (!currentCollection) {
+    lines.push('- Status: ❌ Missing from codebase');
+    return lines;
+  }
+
+  const fieldDiffs = compareFields(specCollection.fields, currentCollection.fields);
+  const indexDiffs = compareIndexes(specCollection.indexes, currentCollection.indexes);
+  const relationDiffs = compareRelations(specCollection.relations, currentCollection.relations);
+
+  lines.push(...fieldDiffs);
+  lines.push(...indexDiffs);
+  lines.push(...relationDiffs);
+
+  return lines;
+}
+
+function buildOverview(
+  spec: ModelSpec,
+  current: CurrentModelMap,
+): { header: string[]; collectionSections: string[] } {
+  const lines: string[] = [];
+  lines.push('# Model Diff');
+  lines.push('');
+  lines.push(`- Generated at: ${new Date().toISOString()}`);
+  lines.push(`- DBML spec: ${path.relative(projectRoot, specPath)}`);
+  lines.push(`- Code map: ${path.relative(projectRoot, currentPath)}`);
+  lines.push('');
+
+  lines.push('## Enum Overview');
+  lines.push(...compareEnums(spec.enums, current.enums));
+  lines.push('');
+
+  const specCollections = Object.keys(spec.collections);
+  const currentCollections = Object.keys(current.collections);
+  const missingCollections = specCollections.filter((name) => !current.collections[name]);
+  const extraCollections = currentCollections.filter((name) => !spec.collections[name]);
+
+  lines.push('## Collections Overview');
+  if (missingCollections.length) {
+    lines.push(`- Missing collections: ${missingCollections.join(', ')}`);
+  }
+  if (extraCollections.length) {
+    lines.push(`- Extra collections: ${extraCollections.join(', ')}`);
+  }
+  if (!missingCollections.length && !extraCollections.length) {
+    lines.push('- Collections: ✅ All collections accounted for');
+  }
+  lines.push('');
+
+  const allCollectionNames = Array.from(new Set([...specCollections, ...currentCollections])).sort();
+  const collectionSections: string[] = [];
+  allCollectionNames.forEach((name) => {
+    const section = generateCollectionDiff(name, spec.collections[name], current.collections[name]);
+    collectionSections.push(...section, '');
+  });
+
+  return { header: lines, collectionSections };
+}
+
+function main(): void {
+  const spec = readJson<ModelSpec>(specPath);
+  const current = readJson<CurrentModelMap>(currentPath);
+
+  const { header, collectionSections } = buildOverview(spec, current);
+  const contents = [...header, ...collectionSections].join('\n');
+  fs.writeFileSync(diffPath, contents, 'utf8');
+  // eslint-disable-next-line no-console
+  console.log(`Model diff written to ${diffPath}`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a tooling script that compares the DBML-derived spec with the current code map
- generate docs/model-diff.md capturing collection, field, index, and relation gaps
- expose a pnpm script to regenerate the diff report

## Testing
- pnpm docs:model-diff

------
https://chatgpt.com/codex/tasks/task_e_68e80d5bfb188320a149d8253f1928ac