### PR TITLE
Align additional schemas with DBML defaults

### DIFF
--- a/src/common/enums/contract.enum.ts
+++ b/src/common/enums/contract.enum.ts
@@ -6,7 +6,7 @@ export enum ContractStatus {
   EXPIRED = 'expired',
 }
 
-export enum ContractProvider {
+export enum EsignProvider {
   NATIVE = 'native',
   DOCUSIGN = 'docusign',
   ADOBESIGN = 'adobesign',

--- a/src/common/enums/inspector.enum.ts
+++ b/src/common/enums/inspector.enum.ts
@@ -1,4 +1,4 @@
-export enum InspectorType {
+export enum InspectionType {
   PRE_RENTAL = 'pre_rental',
   POST_RENTAL = 'post_rental',
 }

--- a/src/common/enums/kycs.enum.ts
+++ b/src/common/enums/kycs.enum.ts
@@ -1,11 +1,11 @@
-export enum KycsType {
+export enum KycType {
   NATIONAL_ID = 'national_id',
   PASSPORT = 'passport',
   DRIVER_LICENSE = 'driver_license',
   OTHER = 'other',
 }
 
-export enum KycsStatus {
+export enum KycStatus {
   SUBMITTED = 'submitted',
   APPROVED = 'approved',
   REJECTED = 'rejected',

--- a/src/common/enums/statusBooking.enum.ts
+++ b/src/common/enums/statusBooking.enum.ts
@@ -1,9 +1,10 @@
-export enum StatusBooking {
+export enum BookingStatus {
   PENDING_VERIFICATION = 'pending_verification',
   VERIFIED = 'verified',
   CANCELLED = 'cancelled',
 }
-export enum VerificationStatus {
+
+export enum BookingVerificationStatus {
   PENDING = 'pending',
   APPROVED = 'approved',
   REJECTED_MISMATCH = 'rejected_mismatch',

--- a/src/common/utils/type.ts
+++ b/src/common/utils/type.ts
@@ -6,19 +6,20 @@ export type BaseJwtUserPayload = {
 };
 
 export type RenterJwtUserPayload = BaseJwtUserPayload & {
-  driver_license: string;
-  address: string;
-  date_of_birth: Date;
-  risk_score: number;
+  driver_license_no?: string;
+  address?: string;
+  date_of_birth?: Date;
+  risk_score?: number;
 };
 
 export type StaffJwtUserPayload = BaseJwtUserPayload & {
-  employeeCode: string;
+  employee_code: string;
   position: string;
   hire_date: Date;
 };
 
 export type AdminJwtUserPayload = BaseJwtUserPayload & {
-  title: string;
+  title?: string;
+  notes?: string;
   hire_date: Date;
 };

--- a/src/models/admin.schema.ts
+++ b/src/models/admin.schema.ts
@@ -5,16 +5,16 @@ import { User } from './user.schema';
 export type AdminDocument = HydratedDocument<Admin>;
 @Schema({ timestamps: { createdAt: 'created_at', updatedAt: false } })
 export class Admin {
-  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true })
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true, unique: true })
   user_id: User;
 
-  @Prop({ required: true, type: String })
-  title: string;
+  @Prop({ type: String })
+  title?: string;
 
-  @Prop({ required: true, type: String })
-  notes: string;
+  @Prop({ type: String })
+  notes?: string;
 
-  @Prop({ required: true, type: Date })
+  @Prop({ required: true, type: Date, default: Date.now })
   hire_date: Date;
 }
 

--- a/src/models/booking.schema.ts
+++ b/src/models/booking.schema.ts
@@ -2,32 +2,32 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import mongoose from 'mongoose';
 import { Renter } from './renter.schema';
 import { VehicleAtStation } from './vehicle_at_station.schema';
-import { StatusBooking, VerificationStatus } from 'src/common/enums/statusBooking.enum';
+import { BookingStatus, BookingVerificationStatus } from 'src/common/enums/statusBooking.enum';
 import { Staff } from './staff.schema';
 
 export type BookingDocument = mongoose.HydratedDocument<Booking>;
 @Schema({ timestamps: { createdAt: 'created_at', updatedAt: false } })
 export class Booking {
-  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'Renter', required: true })
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'Renter', required: true, index: true })
   renter_id: Renter;
 
-  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'VehicleAtStation', required: true })
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'VehicleAtStation', required: true, index: true })
   vehicle_at_station_id: VehicleAtStation;
 
-  @Prop({ required: true, type: Date })
-  booking_create_at: Date;
+  @Prop({ required: true, type: Date, default: Date.now })
+  booking_created_at: Date;
 
-  @Prop({ required: true, type: Date })
-  expected_return_datetime: Date;
+  @Prop({ type: Date })
+  expected_return_datetime?: Date;
 
-  @Prop({ required: true, enum: StatusBooking, default: StatusBooking.PENDING_VERIFICATION })
-  status: StatusBooking;
+  @Prop({ required: true, enum: BookingStatus, default: BookingStatus.PENDING_VERIFICATION, type: String })
+  status: BookingStatus;
 
-  @Prop({ required: true, enum: VerificationStatus, default: VerificationStatus.PENDING })
-  verification_status: VerificationStatus;
+  @Prop({ required: true, enum: BookingVerificationStatus, default: BookingVerificationStatus.PENDING, type: String })
+  verification_status: BookingVerificationStatus;
 
-  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true })
-  verified_by_staff_id: Staff;
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'Staff', index: true })
+  verified_by_staff_id?: Staff;
 
   @Prop({ type: Date })
   verified_at: Date;

--- a/src/models/contract.schema.ts
+++ b/src/models/contract.schema.ts
@@ -1,31 +1,31 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import mongoose, { HydratedDocument } from 'mongoose';
 import { Rental } from './rental.schema';
-import { ContractProvider, ContractStatus } from 'src/common/enums/contract.enum';
+import { ContractStatus, EsignProvider } from 'src/common/enums/contract.enum';
 
 export type ContractDocument = HydratedDocument<Contract>;
 @Schema({ timestamps: { createdAt: 'created_at', updatedAt: 'updated_at' } })
 export class Contract {
-  @Prop({ required: true, type: mongoose.Schema.Types.ObjectId, ref: 'Rental' })
+  @Prop({ required: true, type: mongoose.Schema.Types.ObjectId, ref: 'Rental', unique: true })
   rental_id: Rental;
 
-  @Prop({ required: true, default: 1 })
+  @Prop({ required: true, type: Number, default: 1 })
   version: number;
 
-  @Prop({ required: true, enum: ContractStatus, type: String })
+  @Prop({ required: true, enum: ContractStatus, type: String, default: ContractStatus.ISSUED })
   status: ContractStatus;
 
-  @Prop({ required: true, type: Date })
+  @Prop({ required: true, type: Date, default: Date.now })
   issued_at: Date;
 
-  @Prop({ required: true, type: Date })
-  completed_at: Date;
+  @Prop({ type: Date })
+  completed_at?: Date;
 
-  @Prop({ required: true, enum: ContractProvider, type: String })
-  provider: ContractProvider;
+  @Prop({ required: true, enum: EsignProvider, type: String, default: EsignProvider.NATIVE })
+  provider: EsignProvider;
 
-  @Prop({ required: true, type: String })
-  provider_envelope_id: string;
+  @Prop({ type: String })
+  provider_envelope_id?: string;
 
   @Prop({ required: true, type: String })
   document_url: string;
@@ -36,7 +36,7 @@ export class Contract {
   @Prop({ required: true, type: Boolean, default: false })
   ltv_enabled: boolean;
 
-  @Prop({ required: true, type: String })
-  audit_trail_url: string;
+  @Prop({ type: String })
+  audit_trail_url?: string;
 }
 export const ContractSchema = SchemaFactory.createForClass(Contract);

--- a/src/models/fee.schema.ts
+++ b/src/models/fee.schema.ts
@@ -6,19 +6,21 @@ import { FeeType } from 'src/common/enums/fee.enum';
 export type FeeDocument = mongoose.HydratedDocument<Fee>;
 @Schema({ timestamps: { createdAt: 'created_at', updatedAt: false } })
 export class Fee {
-  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'Booking', required: true })
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'Booking', required: true, index: true })
   booking_id: Booking;
 
-  @Prop({ required: true, enum: FeeType })
+  @Prop({ required: true, enum: FeeType, default: FeeType.DEPOSIT, type: String })
   type: FeeType;
 
   @Prop({ required: true, type: String })
   description: string;
 
-  @Prop({ required: true, type: Number })
-  amount: number;
+  @Prop({ required: true, type: mongoose.Schema.Types.Decimal128 })
+  amount: mongoose.Types.Decimal128;
 
-  @Prop({ required: true, type: String })
+  @Prop({ required: true, type: String, default: 'USD' })
   currency: string;
 }
 export const feeSchema = SchemaFactory.createForClass(Fee);
+
+feeSchema.index({ booking_id: 1 }, { unique: true, name: 'ux_fees_deposit_per_booking' });

--- a/src/models/inspections.schema.ts
+++ b/src/models/inspections.schema.ts
@@ -3,26 +3,28 @@ import { Staff } from './staff.schema';
 import { Rental } from './rental.schema';
 import { SchemaFactory } from '@nestjs/mongoose';
 import mongoose, { HydratedDocument } from 'mongoose';
-import { InspectorType } from 'src/common/enums/inspector.enum';
+import { InspectionType } from 'src/common/enums/inspector.enum';
 export type InspectionDocument = HydratedDocument<Inspection>;
 @Schema({ timestamps: { createdAt: 'created_at', updatedAt: false } })
 export class Inspection {
-  @Prop({ required: true, type: mongoose.Schema.Types.ObjectId, ref: 'Rental' })
+  @Prop({ required: true, type: mongoose.Schema.Types.ObjectId, ref: 'Rental', index: true })
   rental_id: Rental;
 
-  @Prop({ required: true, enum: InspectorType, type: String })
-  type: InspectorType;
+  @Prop({ required: true, enum: InspectionType, type: String, default: InspectionType.PRE_RENTAL })
+  type: InspectionType;
 
-  @Prop({ required: true, type: Date })
-  inspection_at: Date;
+  @Prop({ required: true, type: Date, default: Date.now })
+  inspected_at: Date;
 
-  @Prop({ required: true, type: mongoose.Schema.Types.ObjectId, ref: 'Staff' })
-  inspector_staff_id: Staff;
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'Staff' })
+  inspector_staff_id?: Staff;
 
-  @Prop({ required: true, type: Number })
-  current_battery_capacity_kwh: number;
+  @Prop({ type: Number })
+  current_battery_capacity_kwh?: number;
 
   @Prop({ required: true, type: Number })
   current_mileage: number;
 }
 export const InspectionSchema = SchemaFactory.createForClass(Inspection);
+
+InspectionSchema.index({ rental_id: 1, type: 1 }, { unique: true, name: 'ux_inspections_rental_type' });

--- a/src/models/kycs.schema.ts
+++ b/src/models/kycs.schema.ts
@@ -1,25 +1,31 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import mongoose, { HydratedDocument } from 'mongoose';
 import { Renter } from './renter.schema';
-import { KycsStatus, KycsType } from 'src/common/enums/kycs.enum';
+import { KycStatus, KycType } from 'src/common/enums/kycs.enum';
 
 export type KycsDocument = HydratedDocument<Kycs>;
 @Schema({ timestamps: { createdAt: 'created_at', updatedAt: false } })
 export class Kycs {
-  @Prop({ required: true, type: mongoose.Schema.Types.ObjectId, ref: 'Renter' })
+  @Prop({ required: true, type: mongoose.Schema.Types.ObjectId, ref: 'Renter', index: true })
   renter_id: Renter;
 
-  @Prop({ required: true, enum: KycsType, default: KycsType.DRIVER_LICENSE, type: String })
-  type: KycsType;
+  @Prop({ required: true, enum: KycType, default: KycType.DRIVER_LICENSE, type: String })
+  type: KycType;
 
-  @Prop({ required: true, enum: KycsStatus, default: KycsStatus.SUBMITTED, type: String })
-  status: KycsStatus;
+  @Prop({ required: true, type: String })
+  document_number: string;
+
+  @Prop({ type: Date })
+  expiry_date?: Date;
+
+  @Prop({ required: true, enum: KycStatus, default: KycStatus.SUBMITTED, type: String })
+  status: KycStatus;
 
   @Prop({ required: true, type: Date, default: Date.now })
   submitted_at: Date;
 
-  @Prop({ required: false, type: Date })
-  verified_at: Date;
+  @Prop({ type: Date })
+  verified_at?: Date;
 }
 
 export const KycsSchema = SchemaFactory.createForClass(Kycs);

--- a/src/models/renter.schema.ts
+++ b/src/models/renter.schema.ts
@@ -4,19 +4,25 @@ import { User } from './user.schema';
 export type RenterDocument = HydratedDocument<Renter>;
 @Schema({ timestamps: { createdAt: 'created_at', updatedAt: false } })
 export class Renter {
-  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true })
+  @Prop({
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    unique: true,
+    index: true,
+  })
   user_id: User;
 
-  @Prop({ required: true, type: String })
-  driver_license: string;
+  @Prop({ type: String })
+  driver_license_no?: string;
 
-  @Prop({ required: true, type: String })
-  address: string;
+  @Prop({ type: String })
+  address?: string;
 
-  @Prop({ required: true, type: Date })
-  date_of_birth: Date;
+  @Prop({ type: Date })
+  date_of_birth?: Date;
 
-  @Prop({ required: true, type: Number, default: 0, min: 0, max: 100 })
-  risk_score: number;
+  @Prop({ type: Number, default: 0, min: 0, max: 100 })
+  risk_score?: number;
 }
 export const RenterSchema = SchemaFactory.createForClass(Renter);

--- a/src/models/staff.schema.ts
+++ b/src/models/staff.schema.ts
@@ -5,16 +5,16 @@ import { User } from './user.schema';
 export type StaffDocument = HydratedDocument<Staff>;
 @Schema({ timestamps: { createdAt: 'created_at', updatedAt: false } })
 export class Staff {
-  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true })
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true, unique: true })
   user_id: User;
 
   @Prop({ required: true, unique: true, type: String })
-  employeeCode: string;
+  employee_code: string;
 
   @Prop({ required: true, type: String })
   position: string;
 
-  @Prop({ required: true, type: Date })
+  @Prop({ required: true, type: Date, default: Date.now })
   hire_date: Date;
 }
 export const StaffSchema = SchemaFactory.createForClass(Staff);

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -53,6 +53,7 @@ export class AuthService {
           userPayload = {
             ...userPayload,
             title: admin.title,
+            notes: admin.notes,
             hire_date: admin.hire_date,
           } as AdminJwtUserPayload;
         }
@@ -64,7 +65,7 @@ export class AuthService {
         if (staff) {
           userPayload = {
             ...userPayload,
-            employeeCode: staff.employeeCode,
+            employee_code: staff.employee_code,
             position: staff.position,
             hire_date: staff.hire_date,
           } as StaffJwtUserPayload;
@@ -78,7 +79,7 @@ export class AuthService {
           userPayload = {
             ...userPayload,
             address: renter.address,
-            driver_license: renter.driver_license,
+            driver_license_no: renter.driver_license_no,
             date_of_birth: renter.date_of_birth,
             risk_score: renter.risk_score,
           } as RenterJwtUserPayload;
@@ -126,7 +127,7 @@ export class AuthService {
     const newRenter = new this.renterRepository({
       user_id: newUser._id,
       address: data.address,
-      driver_license: data.driver_license,
+      driver_license_no: data.driver_license_no,
       date_of_birth: data.date_of_birth,
     });
 

--- a/src/modules/auth/dto/renter.dto.ts
+++ b/src/modules/auth/dto/renter.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsDateString } from 'class-validator';
+import { IsString, IsDateString, IsOptional } from 'class-validator';
 import { UserDto } from './user.dto';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -7,21 +7,27 @@ export class RenterDto extends UserDto {
   @ApiProperty({
     description: 'Số giấy phép lái xe của người thuê',
     example: '123456789',
+    required: false,
   })
+  @IsOptional()
   @IsString({ message: 'Số giấy phép lái xe phải là chuỗi' })
-  driver_license: string;
+  driver_license_no?: string;
 
   @ApiProperty({
     description: 'Địa chỉ của người thuê',
     example: '123 Đường Láng, Hà Nội',
+    required: false,
   })
+  @IsOptional()
   @IsString({ message: 'Địa chỉ phải là chuỗi' })
-  address: string;
+  address?: string;
 
   @ApiProperty({
     description: 'Ngày sinh của người thuê (định dạng ISO 8601)',
     example: '1990-01-01',
+    required: false,
   })
+  @IsOptional()
   @IsDateString({}, { message: 'Ngày sinh phải có định dạng hợp lệ (ISO 8601)' })
-  date_of_birth: string;
+  date_of_birth?: string;
 }


### PR DESCRIPTION
## Summary
- enforce unique user references and DB defaults across the admin and staff schemas while exposing optional admin notes
- align bookings, fees, inspections, kycs, and contracts with the DBML by correcting field names, defaults, and indexes
- rename shared enums and update auth payload typing so JWTs surface the new schema-compliant fields

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e80fd87af48320b3b48fe3f417eb69