### PR TITLE
Align reports photo schema with DBML spec

### DIFF
--- a/src/models/reports_photo.schema.ts
+++ b/src/models/reports_photo.schema.ts
@@ -4,17 +4,35 @@ import { Inspection } from './inspections.schema';
 import { Report } from './report.schema';
 
 export type ReportsPhotoDocument = HydratedDocument<ReportsPhoto>;
-@Schema({ timestamps: { createdAt: 'created_at', updatedAt: false } })
+
+@Schema({
+  collection: 'reports_photo',
+  timestamps: { createdAt: 'created_at', updatedAt: false },
+})
 export class ReportsPhoto {
-  @Prop({ required: true, type: mongoose.Schema.Types.ObjectId, ref: 'Report' })
-  report_id: Report;
+  @Prop({
+    type: mongoose.Schema.Types.ObjectId,
+    default: () => new mongoose.Types.ObjectId(),
+    unique: true,
+    required: true,
+  })
+  reports_photo_id: mongoose.Types.ObjectId;
+
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'Report' })
+  report_id?: Report;
 
   @Prop({ required: true, type: mongoose.Schema.Types.ObjectId, ref: 'Inspection' })
   inspection_id: Inspection;
+
   @Prop({ required: true, type: String })
   url: string;
 
-  @Prop({ required: true, type: String })
-  label: string;
+  @Prop({ type: String })
+  label?: string;
 }
+
 export const ReportsPhotoSchema = SchemaFactory.createForClass(ReportsPhoto);
+
+ReportsPhotoSchema.index({ reports_photo_id: 1 }, { unique: true });
+ReportsPhotoSchema.index({ inspection_id: 1 });
+ReportsPhotoSchema.index({ report_id: 1 });


### PR DESCRIPTION
## Summary
- align the reports photo schema with the DBML expectations by adding an explicit reports_photo_id alias and binding the collection name
- ensure optional relationships and fields mirror the spec defaults while keeping timestamps intact
- add indexes on identifier and relation fields to support lookups during migrations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8176dcc9c8320a5868e9789a24c03