### PR TITLE
docs(swagger): document auth controller responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,7 @@ This is a NestJS + MongoDB backend for an electric vehicle rental platform with 
 - Because global validation strips unknown properties, add explicit DTO fields (and `@IsOptional()` where appropriate) before touching request bodies.
 - Reuse custom exceptions (e.g., `NotFoundException`, `ForbiddenException`) instead of Nest defaults so the global interceptor can normalize responses.
 - Absolute imports (`import ... from 'src/...';`) rely on the project’s `baseUrl` config—keep files under `src/` to preserve resolution.
+- Swagger response docs should follow the auth module precedent:
+  - Use the shared `{ msg: string }` contract via `MessageResponseDto` whenever a handler returns a confirmation message.
+  - Document token payloads with `LoginResponseDto` (or a sibling DTO) rather than anonymous object schemas.
+  - Error responses must describe the normalized `{ statusCode, message, errorCode? }` shape exposed by `BaseException`; keep the `errorCode` example `null` unless a specific code is emitted.

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -2,7 +2,12 @@ import { Controller, Post, UseGuards, Request, Body } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LocalGuard } from 'src/common/guards/local.guard';
 import { StaffJwtUserPayload, AdminJwtUserPayload, RenterJwtUserPayload } from 'src/common/utils/type';
-import { ApiBody } from '@nestjs/swagger';
+import {
+  ApiBody,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+} from '@nestjs/swagger';
 import { RenterDto } from './dto/renter.dto';
 import { LoginDto } from './dto/login.dto';
 import { StaffDto } from './dto/staff.dto';
@@ -10,6 +15,23 @@ import { AdminDto } from './dto/admin.dto';
 import { VerifyOtpDto } from 'src/common/mail/dto/verifyOtp.dto';
 import { SendOtpDto } from 'src/common/mail/dto/sendEmail.dto';
 import { ResetPasswordDto } from './dto/resetPassword.dto';
+import { LoginResponseDto } from './dto/login-response.dto';
+import { MessageResponseDto } from './dto/message-response.dto';
+
+const buildErrorResponse = (statusCode: number, messageExample: string) => ({
+  schema: {
+    type: 'object',
+    properties: {
+      statusCode: { type: 'integer', example: statusCode },
+      message: { type: 'string', example: messageExample },
+      errorCode: {
+        type: 'string',
+        nullable: true,
+        example: 'AUTH_ERROR_CODE',
+      },
+    },
+  },
+});
 
 @Controller('auth')
 export class AuthController {
@@ -18,42 +40,83 @@ export class AuthController {
   @UseGuards(LocalGuard)
   @ApiBody({ type: LoginDto })
   @Post('login')
+  @ApiCreatedResponse({ description: 'JWT access token', type: LoginResponseDto })
+  @ApiForbiddenResponse({
+    description: 'Incorrect password',
+    ...buildErrorResponse(403, 'Wrong password'),
+  })
+  @ApiNotFoundResponse({
+    description: 'User not found',
+    ...buildErrorResponse(404, 'User not found'),
+  })
   login(@Request() req: { user: RenterJwtUserPayload | StaffJwtUserPayload | AdminJwtUserPayload }) {
     return this.authService.login(req.user);
   }
 
   @Post('register/renter')
   @ApiBody({ type: RenterDto })
+  @ApiCreatedResponse({
+    description: 'Renter account created',
+    type: MessageResponseDto,
+  })
   async createRenter(@Body() body: RenterDto) {
     return this.authService.createRenter(body);
   }
 
   @Post('register/staff')
   @ApiBody({ type: StaffDto })
+  @ApiCreatedResponse({
+    description: 'Staff account created',
+    type: MessageResponseDto,
+  })
   async createStaff(@Body() body: StaffDto) {
     return this.authService.createStaff(body);
   }
 
   @Post('register/admin')
   @ApiBody({ type: AdminDto })
+  @ApiCreatedResponse({
+    description: 'Admin account created',
+    type: MessageResponseDto,
+  })
   async createAdmin(@Body() body: AdminDto) {
     return this.authService.createAdmin(body);
   }
 
   @Post('send-otp')
   @ApiBody({ type: SendOtpDto })
+  @ApiCreatedResponse({
+    description: 'OTP email sent',
+    type: MessageResponseDto,
+  })
   async sendOtp(@Body() body: SendOtpDto) {
     return this.authService.sendOtp(body);
   }
 
   @Post('verify-email')
   @ApiBody({ type: VerifyOtpDto })
+  @ApiCreatedResponse({
+    description: 'OTP verified successfully',
+    type: MessageResponseDto,
+  })
+  @ApiForbiddenResponse({
+    description: 'Invalid OTP code',
+    ...buildErrorResponse(403, 'Invalid OTP'),
+  })
   async verifyEmail(@Body() body: VerifyOtpDto) {
     return this.authService.verifyEmail(body);
   }
 
   @Post('reset-password')
   @ApiBody({ type: ResetPasswordDto })
+  @ApiCreatedResponse({
+    description: 'Password reset completed',
+    type: MessageResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: 'User not found for provided email',
+    ...buildErrorResponse(404, 'User not found'),
+  })
   async resetPassword(@Body() body: ResetPasswordDto) {
     return this.authService.resetPassword(body);
   }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -21,13 +21,14 @@ import { MessageResponseDto } from './dto/message-response.dto';
 const buildErrorResponse = (statusCode: number, messageExample: string) => ({
   schema: {
     type: 'object',
+    required: ['statusCode', 'message'],
     properties: {
       statusCode: { type: 'integer', example: statusCode },
       message: { type: 'string', example: messageExample },
       errorCode: {
         type: 'string',
         nullable: true,
-        example: 'AUTH_ERROR_CODE',
+        example: null,
       },
     },
   },

--- a/src/modules/auth/dto/login-response.dto.ts
+++ b/src/modules/auth/dto/login-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class LoginResponseDto {
+  @ApiProperty({
+    description: 'JWT access token that authorizes subsequent requests',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  access_token: string;
+}

--- a/src/modules/auth/dto/message-response.dto.ts
+++ b/src/modules/auth/dto/message-response.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MessageResponseDto {
+  @ApiProperty({ description: 'Human-readable summary of the completed action' })
+  msg: string;
+}

--- a/src/modules/auth/dto/message-response.dto.ts
+++ b/src/modules/auth/dto/message-response.dto.ts
@@ -1,6 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class MessageResponseDto {
-  @ApiProperty({ description: 'Human-readable summary of the completed action' })
+  @ApiProperty({
+    description: 'Human-readable summary of the completed action',
+    example: 'Create renter successfully',
+  })
   msg: string;
 }


### PR DESCRIPTION
## Summary
- add swagger response decorators for auth endpoints covering success and error outcomes
- introduce DTOs describing JWT token and generic message payloads for reuse in swagger docs
- centralize the shared error response schema to keep documented shapes consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8ffdbf7cc83208c7668fbdadd7dbf